### PR TITLE
Make keyterm scanning case insensitive

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/keyterm/KeyTermActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/keyterm/KeyTermActivity.kt
@@ -66,12 +66,13 @@ class KeyTermActivity : AppCompatActivity() {
     companion object {
         fun stringToKeytermLink(string: String, context: Context?): SpannableString{
             val spannableString = SpannableString(string)
-            if(Workspace.termsToKeyterms.containsKey(string)){
+            if(Workspace.termsToKeyterms.containsKey(string.toLowerCase())){
                 val clickableSpan = object : ClickableSpan() {
                     override fun onClick(textView : View) {
                         //bundle up the key term to send to new activity
                         val intent = Intent(context, KeyTermActivity::class.java)
-                        intent.putExtra("Keyterm", Workspace.termsToKeyterms[string])
+                        val keyterm = Workspace.termsToKeyterms[string.toLowerCase()]
+                        intent.putExtra("Keyterm", keyterm)
                         context?.startActivity(intent)
                     }
 

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -154,9 +154,9 @@ object Workspace{
         val termsToKeyterms: MutableMap<String, Keyterm> = mutableMapOf()
 
         for(keyterm: Keyterm in keyterms) {
-            termsToKeyterms.put(keyterm.term, keyterm)
+            termsToKeyterms[keyterm.term.toLowerCase()] = keyterm
             for (termForm in keyterm.termForms) {
-                termsToKeyterms.put(termForm, keyterm)
+                termsToKeyterms[termForm.toLowerCase()] = keyterm
             }
         }
 
@@ -166,7 +166,7 @@ object Workspace{
     private fun stringToList(field: String, separator: String): List<String>{
         if(field.isNotEmpty()) {
             val list = field.split(separator)
-            val trimmedList = list.map { it.trim() }.toMutableList()
+            val trimmedList = list.asSequence().map { it.trim() }.toMutableList()
             trimmedList.remove("")
             return trimmedList
         }


### PR DESCRIPTION
Really short update that will find more of the keyterms from the keyterms document. A future issue may be to select specific keyterms and case sensitive (names, proper nouns, etc.). A future issue is created for scanning for multi-word keyterms as this type of algorithm is a bit more complicated.