### PR TITLE
Issue #503 - Rouge Story File

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/phase/PhaseBaseActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/phase/PhaseBaseActivity.kt
@@ -67,7 +67,12 @@ abstract class PhaseBaseActivity : BaseActivity(), AdapterView.OnItemSelectedLis
         super.onPause()
         story.lastSlideNum = Workspace.activeSlideNum
         story.lastPhaseType = Workspace.activePhase.phaseType
-        Thread(Runnable{story.toJson(this)}).start()
+
+        // Issue #503, it is possible for the user to change workspaces causing a rouge story
+        // to save. Instead, ensure that the story exists in the current workspace before saving.
+        if(Workspace.Stories.contains(story)) {
+            Thread(Runnable { story.toJson(this) }).start()
+        }
     }
 
     //Override setContentView to coerce into child view.


### PR DESCRIPTION
Prevent Story Producer from saving a story that doesn't belong in the workspace. Ensures that the story exists in the workspace before trying to save it.

Steps to reproduce: (from #503)
- Prepare SD card with two SP Template folders:
- ‘SP Templates A’ with .bloom templates 001 and 002
- ‘SP Templates B’ with .bloom templates 006 and 007
- Run SP 3.0.2
- Select folder ‘SP Templates A’
- Open story 001. Go to Translation phase.
- With story 001 still open, do Menu > Select SP Templates folder and select SP Templates B.
- Unexpectedly, SP writes a new a lone rogue story.json file in a new rogue folder:
- SP Templates B / 001 Widow’s Gift / project
- This file and folder should not be written.
