### PR TITLE
Issue #517 - Add Local Contact to the Local Credits

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="title_activity_splash_screen">Story Producer</string>
 
     <!-- Local Credits -->
-    <string name="LC_starting_text">Language:\nTranslated by:\nPhotography by:\nNarration / Voice Acting by:\nLocal Song by:</string>
+    <string name="LC_starting_text">Local Contact (phone/email):\nLanguage:\nTranslated by:\nPhotography by:\nNarration / Voice Acting by:\nLocal Song by:</string>
     <string name="LC_prompt">Local Credits will be added during voice acting.</string>
 
     <!-- Local Song -->


### PR DESCRIPTION
Issue #517. This adds a new line to the beginning of the local credits saying: "Local Contact (phone/email):". Here is an example of the new change.
<img width="500" alt="Screen Shot 2020-10-30 at 9 27 03 AM" src="https://user-images.githubusercontent.com/15131163/97710635-62cbc180-1a92-11eb-9def-62335d7be46a.png">


This has been tested with the other local credit changes made in #419. 