### PR TITLE
Implement continuous integration via TeamCity and Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 /captures
 *debug*
 *release*
+
+# The instructions in README.md for building a locally signed APK include 
+# putting these files in the root directory. We don't want them checked in.
+/keystore.properties
+/*.jks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: android
+os: linux
+dist: trusty
+
+android:
+  components:
+    - build-tools-29.0.2
+    - android-29
+
+script:
+  - echo "Travis branch is $TRAVIS_BRANCH"
+  - echo "Travis branch is in pull request $TRAVIS_PULL_REQUEST"
+  - curl -s "https://sil-storyproducer-resources.s3.amazonaws.com/dev/dev-keystore.jks" -o "dev-keystore.jks"
+  - curl -s "https://sil-storyproducer-resources.s3.amazonaws.com/dev/keystore.properties" -o "keystore.properties"
+  - ./gradlew test

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ Translate and produce stories (starting with templates in a major language made 
 * FINALIZE/CREATE new videos
 * SHARE the videos
 
+## Creating a signed APK
+
+To install onto a device, an APK needs to be signed. When uploading to Google Play, it has to be signed by the same
+keystore that was used on the initial upload. For testing on a device using side loading, it can be signed with any
+keystore. We do not want to check in a keystore to the repo, so developers can either download a pre-made set of files or
+create their own.
+
+To download pre-made set of files:
+* run these commands in the root directory
+    * `curl "https://sil-storyproducer-resources.s3.amazonaws.com/dev/dev-keystore.jks" -o "dev-keystore.jks"`
+    * `curl "https://sil-storyproducer-resources.s3.amazonaws.com/dev/keystore.properties" -o "keystore.properties"`
+
+To create the set of files:
+* [create a keystore](https://stackoverflow.com/questions/3997748/how-can-i-create-a-keystore) (a .jks file) and
+save in the root directory.
+* create keystore.properties with the values:
+    * storeFile=<keystore-filename>.jks
+    * storePassword=<store-password>
+    * keyAlias=<key-alias>
+    * keyPassword=<key-password>
+* run `gradle clean assembleRelease`
+
 ## Installing the application
 * Minimum Requirements:  
     * Android 5.x.x; Android 8 is required to create 3GP output videos

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.gms.google-services'
 
+def keystorePropertiesFile = new File(rootProject.projectDir, 'keystore.properties')
+
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.2'
@@ -21,8 +23,28 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    signingConfigs {
+        if (keystorePropertiesFile.isFile()) {
+            logger.lifecycle("keystore.properties exists. Sign APK.")
+            def keystoreProperties = new Properties()
+            keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile rootProject.file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+        else
+        {
+            logger.lifecycle("keystore.properties not found. Unable to sign APK.")
+        }
+    }
     buildTypes {
         release {
+            if (keystorePropertiesFile.isFile()) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
@@ -47,6 +69,7 @@ android {
         }
     }
 }
+
 
 repositories {
     mavenCentral()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 17
-        versionName '3.0.2.0001'
+        versionName '3.0.2'
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -38,6 +38,19 @@ android {
         else
         {
             logger.lifecycle("keystore.properties not found. Unable to sign APK.")
+        }
+    }
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            def versionPart = variant.name;
+            if (variant.name == "release") {
+                if (keystorePropertiesFile.isFile()) {
+                    versionPart = variant.versionName;
+                } else {
+                    versionPart = versionPart + "-not-signed";
+                }
+            }
+            outputFileName = "SP-${versionPart}.apk"
         }
     }
     buildTypes {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 kapt.incremental.apt=true
+
+# When building in TeamCity, the build was failing on jetifier.  This worked around it.
+# https://github.com/square/moshi/issues/804#issuecomment-466456323
+android.jetifier.blacklist = kotlin-compiler-embeddable-.*\\.jar


### PR DESCRIPTION
* Disable jetifier for kotlin compiler (broke on TeamCity)
* Conditionally sign APK
* Include instructions in README.md for creating signed APK
* change versionName back to '3.0.2'
* when signing, include versionName in the APK outputFileName