### PR TITLE
Issue #539 - Template Corruption

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/activity/BaseActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/activity/BaseActivity.kt
@@ -54,7 +54,7 @@ open class BaseActivity : AppCompatActivity(), BaseActivityView {
     }
 
     fun initWorkspace() {
-        Workspace.initializeWorskpace(this)
+        Workspace.initializeWorkspace(this)
 
         if (Workspace.workdocfile.isDirectory) {
             controller.updateStories()

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -86,7 +86,7 @@ object Workspace{
 
     fun setupWorkspacePath(context: Context, uri: Uri) {
         try {
-            // Issue 539 - Reset Story info to detach from old Story
+            // Issue 539 - Reset Story info to detach from current Story, if any
             activeStory = emptyStory()
 
             // Initiate new workspace path

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -76,7 +76,7 @@ object Workspace{
 
     val WORKSPACE_KEY = "org.sil.storyproducer.model.workspace"
 
-    fun initializeWorskpace(activity: Activity) {
+    fun initializeWorkspace(activity: Activity) {
         //first, see if there is already a workspace in shared preferences
         prefs = activity.getSharedPreferences(WORKSPACE_KEY, Context.MODE_PRIVATE)
         setupWorkspacePath(activity, Uri.parse(prefs!!.getString("workspace", "")))
@@ -86,9 +86,25 @@ object Workspace{
 
     fun setupWorkspacePath(context: Context, uri: Uri) {
         try {
+            val outputDir: File = context.cacheDir
+            val outputFile = File.createTempFile("prefix", ".tmp", outputDir)
+            var newDoc : DocumentFile = DocumentFile.fromFile(outputFile)
+
+            // Issue 539 - Create a temporary file to become the new workspace
+            // Reset Story info to detach from old Story
+            workdocfile = newDoc
+
+            Stories.clear()
+            activeStory = emptyStory()
+
+            // Initiate new workspace
             workdocfile = DocumentFile.fromTreeUri(context, uri)!!
             registration.load(context)
+
+            newDoc.delete()
+            outputFile.delete()
         } catch (e: Exception) {
+            Log.e("setupWorkspacePath", "Error setting up new workspace path!", e)
         }
     }
 

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -89,7 +89,7 @@ object Workspace{
             // Issue 539 - Reset Story info to detach from old Story
             activeStory = emptyStory()
 
-            // Initiate new workspace
+            // Initiate new workspace path
             workdocfile = DocumentFile.fromTreeUri(context, uri)!!
             registration.load(context)
         } catch (e: Exception) {

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -86,23 +86,12 @@ object Workspace{
 
     fun setupWorkspacePath(context: Context, uri: Uri) {
         try {
-            val outputDir: File = context.cacheDir
-            val outputFile = File.createTempFile("prefix", ".tmp", outputDir)
-            var newDoc : DocumentFile = DocumentFile.fromFile(outputFile)
-
-            // Issue 539 - Create a temporary file to become the new workspace
-            // Reset Story info to detach from old Story
-            workdocfile = newDoc
-
-            Stories.clear()
+            // Issue 539 - Reset Story info to detach from old Story
             activeStory = emptyStory()
 
             // Initiate new workspace
             workdocfile = DocumentFile.fromTreeUri(context, uri)!!
             registration.load(context)
-
-            newDoc.delete()
-            outputFile.delete()
         } catch (e: Exception) {
             Log.e("setupWorkspacePath", "Error setting up new workspace path!", e)
         }


### PR DESCRIPTION
#539 

When switching to a workspace SP was somehow holding onto previous information during the transformation process. This change fixes that by resetting the Story information to an empty story before switching the workspace over.

Testing Steps
- Clean Directory
- Add story 001.bloom
- Open SP 3.0.3 and start story
- Leave SP open (at the Story Templates list e.g.)
- Use file manager to add 002.bloom to the same directory as story 001
- In SP, do "Select SP Templates folder" to rescan the directory