### PR TITLE
Fix data loss problem for Android 10 & 11 (#549)

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/model/Registration.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Registration.kt
@@ -28,7 +28,12 @@ class Registration{
         }
     }
     fun save(context: Context){
-        val oStream = getChildOutputStream(context,REGISTRATION_FILENAME,"")
+        // 03/08/2021 - DKH  Fix file corruption in registration.json file (see issue 549)
+        // Since we are not saving anything in the current registration file, truncate the file
+        // to eliminate all data.  Previously, the file was open with default mode of "w" which
+        // preserved all the data in the file. If the new file is smaller in size,
+        // there are garbage characters left.
+        val oStream = getChildOutputStream(context,REGISTRATION_FILENAME,"","wt")
         if(oStream != null) {
             try {
                 oStream.write(jsonData.toString(1).toByteArray(Charsets.UTF_8))

--- a/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
@@ -73,9 +73,15 @@ fun getDownsample(context: Context, relPath: String,
     return max(1,min(options.outHeight/dstHeight,options.outWidth/dstWidth))
 }
 
+
 fun getStoryChildOutputStream(context: Context, relPath: String, mimeType: String = "", dirRoot: String = Workspace.activeDirRoot) : OutputStream? {
     if (dirRoot == "") return null
-    return getChildOutputStream(context, "$dirRoot/$relPath", mimeType)
+    // DKH-Updated 03/04/2021 to fix Issue #549: Lost data during story creation for Android 10 & 11
+    // Specify "truncate file" on open which will start with zero data in the file.
+    // Previously, data was not truncated which would leave garbage characters at the EOF when
+    // writing a smaller file.  Garbage data caused story.json file corruption.
+    // FIX - Added the ability to pass mode to getChildOutputStream.  Pass mode of write/truncate ("wt")
+    return getChildOutputStream(context, "$dirRoot/$relPath", mimeType,"wt")
 }
 
 fun storyRelPathExists(context: Context, relPath: String, dirRoot: String = Workspace.activeDirRoot) : Boolean{
@@ -124,8 +130,15 @@ fun getText(context: Context, relPath: String) : String? {
     return null
 }
 
-fun getChildOutputStream(context: Context, relPath: String, mimeType: String = "") : OutputStream? {
-    val pfd = getPFD(context, relPath, mimeType,"w")
+// DKH-Updated 03/04/2021 to fix Issue #549: Lost data during story creation for Android 10 & 11
+// Expose mode to calling interfaces.  This allows caller to truncate the target (relPath) on an open
+// Before change, mode was hardwired to "w".  On a "w" open, all the data from the previous writes to
+// the file is still present. If the new file is smaller in size, there are garbage characters left
+// from the previous file open/write/close operations.
+// Other calling interfaces will see no change since the default to mode is "w" (as before).
+// To get file truncation, use "wt" as the mode argument.
+fun getChildOutputStream(context: Context, relPath: String, mimeType: String = "", mode: String = "w") : OutputStream? {
+    val pfd = getPFD(context, relPath, mimeType, mode)
     var oStream: OutputStream? = null
     try {
         oStream = ParcelFileDescriptor.AutoCloseOutputStream(pfd)


### PR DESCRIPTION
Problem:  Users would lose all their data after the Accuracy Check phase if they exited Story Producer on an Android 10 & 11 platform.
Solution: Between phases, the story.json file is opened and then written.  story.json was not truncated on the open, but over written with the new data.  If the new data was smaller than the previous data in the file, garbage characters from the old data would be left in the file.  This changes opens story.json in truncate mode which deletes all the old data in the file and ensures that only the new data is written to the file.
Test:  Tested fix on Pixel 2/Android 9 and Pixel 5/Android 11.