### PR TITLE
Fix for #548 Android 11 SP crash in finalize; no video produced

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
@@ -81,9 +81,9 @@ fun getDownsample(context: Context, relPath: String,
     // iStream.available() can throw an exception, so a try/catch was added.
     // restructure routine for better flow
     var ds:Int = 1
-    if(relPath != "") { // return ds default value
+    if(relPath != "") { // If empty string: return ds default value
         val iStream = getStoryChildInputStream(context, relPath, story.title)
-        if(iStream != null) { // could not assign an iStream to the file, return ds default value
+        if(iStream != null) { // If null: could not assign an iStream to the file, return ds default value
             try {
                 if (iStream.available() != 0) {  // if a throw or file is empty, return default value
                     // got data in the file, so process it


### PR DESCRIPTION
Problem: During finalize state on an Android 11/Pixel 5 configuration, Story Producer would crash when trying to create a Story that contained a video.

Solution:  The problem was traced to not catching an exception for call "iStream.available()" in SlideService.kt and FileIO.kt.   iStream is an input stream that was opened on a file named "" (empty string).  For Android 11, iStream.available() throws an exception.  For previous versions of Android it returns a 0.