### PR TITLE
Remove the 'Remote' item option from the location type in registration

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,7 +126,7 @@
 
     <string-array name="location_type_list">
         <item>Local</item>
-        <item>Remote</item>
+        <!--<item>Remote</item>-->
     </string-array>
 
     <!--Navigation Drawer Labels (Main Activity) -->


### PR DESCRIPTION
Only the local option is currently available, so the 'remote' option remains commented out until implemented!

![Screen Shot 2021-03-24 at 10 33 48 PM](https://user-images.githubusercontent.com/38381688/112410140-19099f00-8cf1-11eb-98ef-ef96ae0d83d8.png)
