### PR TITLE
Issue #559: Fix for Registration Data Loss in CI Build

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
@@ -249,6 +249,10 @@ open class RegistrationActivity : AppCompatActivity() {
      */
     private fun getStoredValueForView(view: View): String {
         var viewName = resources.getResourceName(view.id)
+        // dkh - 4/19/2021 PR #559: Registration data loss in Continuous builds
+        // The ID_PREFIX must be removed from the unique token before passing the field name to
+        // the JASON search routines that finds the data for the field name
+        // See comments surrounding the ID_PREFIX declaration for more info
         viewName = viewName.replace(ID_PREFIX, "")
         return Workspace.registration.getString(viewName, "")
     }
@@ -578,7 +582,20 @@ open class RegistrationActivity : AppCompatActivity() {
 
         val EMAIL_SENT = "registration_email_sent"
 
-        private val ID_PREFIX = "org.sil.storyproducer:id/input_"
+        // dkh - 4/19/2021 PR #559: Registration data loss in Continuous builds
+        // ID_PREFIX is prepended to each field in the JSON registration file
+        // to create a unique token to store the data within story producer.
+        // For build type of Continuous or Release, the product id changes, which impacts the
+        // unique token. The product id is found in the google-services.json file.
+        // Here are the unique token strings for JSON registration file field "ethnologue" according
+        // to build type:
+        // Release build:       org.sil.storyproducer:id/input_ethnologue
+        // Continuous build:    org.sil.storyproducer.ci:id/input_ethnologue
+        // Use a regex expression to match the change in product id
+        // This expression matches any a-z or "." zero or more times
+        // This will also match a Debug build when the debug build conforms to the product id
+        // naming standard described above
+        private val ID_PREFIX = "org.sil.storyproducer[.a-z]*:id/input_".toRegex()
         private val SHOW_KEYBOARD = true
         private val CLOSE_KEYBOARD = false
 


### PR DESCRIPTION
Problem: Data saved during registration is not persisted when registration data is updated
Solution: Introduction of a different package name in the google-services.json for continuous builds caused a error when parsing the registration.json file.  The RegistrationActivity.kt file was updated to account for the new package name.