### PR TITLE
Sp 568 firebase4 debug blds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             resValue("bool", "FIREBASE_ANALYTICS_DEACTIVATED", "false")
         }
+        // dkh - 5/3/21  - These changes came  from Chris Hubbard (pull request 568)
+        // Updated applicationIdSuffix to allow debug versions of app crashes to be captured separate from
+        // continuous or product builds in Firebase.  Also, make sure we capture analytics by
+        // setting FIREBASE_ANALYTICS_DEACTIVATED to false.
+        //"package_name" in debug\google-services.json was also changed.  Side effect of
+        // changing the package_name is that field names in the JASON registration parsing were
+        // affected.  See Issue #559 for a more detailed explanation.
         debug {
             versionNameSuffix ".debug"
             applicationIdSuffix ".debug"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,8 @@ android {
         }
         debug {
             versionNameSuffix ".debug"
-            resValue("bool", "FIREBASE_ANALYTICS_DEACTIVATED", "true")
+            applicationIdSuffix ".debug"
+            resValue("bool", "FIREBASE_ANALYTICS_DEACTIVATED", "false")
         }
         continuous {
             initWith release

--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -1,42 +1,34 @@
 {
   "project_info": {
-    "project_number": "330300578161",
-    "firebase_url": "https://storyproducer-52e13.firebaseio.com",
-    "project_id": "storyproducer-52e13",
-    "storage_bucket": "storyproducer-52e13.appspot.com"
+    "project_number": "89996807106",
+    "firebase_url": "https://storyproducerdebug.firebaseio.com",
+    "project_id": "storyproducerdebug",
+    "storage_bucket": "storyproducerdebug.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:330300578161:android:31950a0a5399676e",
+        "mobilesdk_app_id": "1:89996807106:android:905fb87a3796b480ece45b",
         "android_client_info": {
-          "package_name": "org.sil.storyproducer"
+          "package_name": "org.sil.storyproducer.debug"
         }
       },
       "oauth_client": [
         {
-          "client_id": "330300578161-qmmv0thtc025b42tbdqpc62ur52epe92.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "org.sil.storyproducer",
-            "certificate_hash": "cc8b1d51bba2b65e7ab6ce9fc83e25966a5c609f"
-          }
-        },
-        {
-          "client_id": "330300578161-kfj18tj7e82d7tu12eor4jlrvmcj3tli.apps.googleusercontent.com",
+          "client_id": "89996807106-46acr978hig6s5s8kfpb685estbds700.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyAcNywfP74zdkZQwzNANn8R1nMZpJIcnFQ"
+          "current_key": "AIzaSyCkA1VGDTPRcAuVzFJ6snAxAhyV8i2q8N8"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "330300578161-kfj18tj7e82d7tu12eor4jlrvmcj3tli.apps.googleusercontent.com",
+              "client_id": "89996807106-46acr978hig6s5s8kfpb685estbds700.apps.googleusercontent.com",
               "client_type": 3
             }
           ]


### PR DESCRIPTION
Problem: Debug APK crashes are reported to the Firebase Product repository.
Solution: Change build.gradle and debug/google-services.json to specify that debug APKs are recorded in a separate Firebase repository called StoryProducerDebug.
Testing: Executed Story Producer and changed JSON registration file.  Viewed list of story templates and then selected "Update Registration" from menu.  Changes were still in JSON registration file (this was expected).
Exited Story Producer and inserted a corrupt JSON registration file.  Executed Story Producer and viewed the JSON registration files.  All changes were gone because file was corrupted (this was expected).  
Viewed Firebase and the JSON registration file corruption showed up as a Non-fatals event.