### PR TITLE
Issue #573: SP hangs on Registration Submit

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
@@ -81,10 +81,22 @@ open class BaseActivity : AppCompatActivity(), BaseActivityView {
         startActivity(Intent(this, MainActivity::class.java))
         finish()
     }
-
-    override fun showRegistration() {
+    // DKH - 05/12/2021
+    // Issue #573: SP will hang/crash when submitting registration
+    // showRegistration Argument allows calling function in current Activity to terminate the
+    // current Activity and then show the Registration screen via the RegistrationActivity
+    // Any MainActivity function should set executeFinishActivity to false.  MainActivity should
+    // always exist.
+    // Activities like LearnActivity will exit by using the default value of true
+    // After the RegistrationActivity completes, control is returned to the MainActivity
+    // where the list of story templates are displayed
+    override fun showRegistration(executeFinishActivity: Boolean) {
         startActivity(Intent(this, RegistrationActivity::class.java))
-        finish()
+
+        // If true, then this Activity will finish and exit
+        if(executeFinishActivity) {
+            finish()
+        }
     }
 
     override fun showReadingTemplatesDialog(controller: BaseController) {

--- a/app/src/main/java/org/sil/storyproducer/controller/BaseController.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/BaseController.kt
@@ -79,11 +79,15 @@ open class BaseController(
     }
 
     private fun onStoriesUpdated() {
-        if (Workspace.registration.complete) {
-            view.showMain()
-        } else {
-            view.showRegistration()
+        if (!Workspace.registration.complete) {
+            // DKH - 05/12/2021
+            // Issue #573: SP will hang/crash when submitting registration
+            // Tell MainActivity to display the registration upon MainActivity startup
+            Workspace.showRegistration = true
         }
+        // activate the MainActivity which if necessary, will call RegistrationActivity to display
+        // the registration
+        view.showMain()
     }
 
 }

--- a/app/src/main/java/org/sil/storyproducer/controller/BaseController.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/BaseController.kt
@@ -82,6 +82,7 @@ open class BaseController(
         if (!Workspace.registration.complete) {
             // DKH - 05/12/2021
             // Issue #573: SP will hang/crash when submitting registration
+            // Don't call view.showRegistration() directly,
             // Tell MainActivity to display the registration upon MainActivity startup
             Workspace.showRegistration = true
         }

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -59,6 +59,21 @@ class MainActivity : BaseActivity(), Serializable {
             initWorkspace()
         }
 
+        if (Workspace.showRegistration) {
+            // DKH - 05/12/2021
+            // Issue #573: SP will hang/crash when submitting registration
+            // Indicates that MainActivity should create the RegistrationActivity and show the
+            // registration screen.
+            // This is set in BaseController function onStoriesUpdated()
+            Workspace.showRegistration = false
+
+            // When starting the RegistrationActivity from the MainActivity, specify that
+            // finish should not be called on the MainActivity.
+            // This is done by setting executeFinishActivity to false.
+            // After the RegistrationActivity is complete, MainActivity will then display
+            // the story template list
+            showRegistration(false)
+        }
         GlobalScope.launch {
             runOnUiThread {
                 supportFragmentManager.beginTransaction().add(R.id.fragment_container, storyList).commit()
@@ -146,7 +161,14 @@ class MainActivity : BaseActivity(), Serializable {
                 // Current fragment
             }
             R.id.nav_registration -> {
-                showRegistration()
+                // DKH - 05/10/2021 Issue 573: SP will hang/crash when submitting registration
+                // The MainActivity thread is responsible for displaying  story templates
+                // and allowing the user to select  a registration update via this menu option.
+                // So, when calling the RegistrationActivity from the MainActivity, specify that
+                // finish should not be called.  This is done by setting executeFinishActivity to false.
+                // After the RegistrationActivity is complete, MainActivity will then display
+                // the story template list
+                showRegistration(false)
             }
             R.id.nav_about -> {
                 showAboutDialog()

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -62,8 +62,8 @@ class MainActivity : BaseActivity(), Serializable {
         if (Workspace.showRegistration) {
             // DKH - 05/12/2021
             // Issue #573: SP will hang/crash when submitting registration
-            // Indicates that MainActivity should create the RegistrationActivity and show the
-            // registration screen.
+            // This flag indicates that MainActivity should create the
+            // RegistrationActivity and show the registration screen.
             // This is set in BaseController function onStoriesUpdated()
             Workspace.showRegistration = false
 

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -35,7 +35,7 @@ object Workspace{
     var prefs: SharedPreferences? = null
     // DKH - 05/12/2021
     // Issue #573: SP will hang/crash when submitting registration
-    // Indicates whether MainActivity should call the RegistrationActivity to allow
+    // This flag indicates whether MainActivity should call the RegistrationActivity to allow
     // the user to update the registration
     // This is set in BaseController function onStoriesUpdated()
     var showRegistration = false

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -33,6 +33,12 @@ object Workspace{
     var activePhaseIndex: Int = -1
     var isInitialized = false
     var prefs: SharedPreferences? = null
+    // DKH - 05/12/2021
+    // Issue #573: SP will hang/crash when submitting registration
+    // Indicates whether MainActivity should call the RegistrationActivity to allow
+    // the user to update the registration
+    // This is set in BaseController function onStoriesUpdated()
+    var showRegistration = false
 
     var activeStory: Story = emptyStory()
     set(value){

--- a/app/src/main/java/org/sil/storyproducer/view/BaseActivityView.kt
+++ b/app/src/main/java/org/sil/storyproducer/view/BaseActivityView.kt
@@ -8,7 +8,13 @@ interface BaseActivityView {
 
     fun startActivityForResult(intent: Intent, request: Int)
     fun showMain()
-    fun showRegistration()
+    // DKH - 05/12/2021
+    // Issue #573: SP will hang/crash when submitting registration
+    // Updated showRegistration interface to allow calling function in the current activity
+    // to specify whether the  finish() call should be executed.  The finish call terminates
+    // the current activity.  Value true means call finish(). Calling showRegistration with
+    // no argument sets executeFinishActivity to true
+    fun showRegistration(executeFinishActivity: Boolean = true)
     fun takePersistableUriPermission(uri: Uri)
     fun showReadingTemplatesDialog(controller: BaseController)
     fun updateReadingTemplatesDialog(current: Int, total: Int, currentTemplate: String)


### PR DESCRIPTION
Problem: SP hangs on Registration Submit
Solution:  Problem was traced to terminating the MainActivity before calling the RegistrationActivity.  The submit button on the RegistrationActivity forces Story Producer to the background for the submission of the data via another APP. When the Story Producer APP becomes active, the MainActivity is not around to orchestrate story production.
Testing: Ran through several scenarios of registration submissions for Android 11 on a Pixel 5 and Android 8.1 on a Pixel 3.