### PR TITLE
Added exception Handling & log messages for Story to/from Jason

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/model/StoryIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/StoryIO.kt
@@ -43,7 +43,7 @@ fun Story.toJson(context: Context){
             // found in Android studio
             // (i.e., to view message during debug, create a Logcat filter for "Log Message:"
             // looking for "SP::")
-            Timber.wtf("SP::(%s)", errInfo)
+            Timber.e("SP::(%s)", errInfo) // uses Kotlin Log class with severity level: Error
         }
         finally{oStream.close()}
     }
@@ -81,7 +81,7 @@ fun storyFromJson(context: Context, storyTitle: String): Story?{
         // found in Android studio
         // (i.e., to view message during debug, create a Logcat filter for "Log Message:"
         // looking for "SP::")
-        Timber.wtf("SP::(%s)", errInfo)
+        Timber.e("SP::(%s)", errInfo) // uses Kotlin Log class with severity level: Error
 
         return null
     }


### PR DESCRIPTION
Report Story Parse Exceptions and Handle them appropriately.
**Solution**: Log a message and an exception to Firebase when this happens.  Also, log a message to the Android system log file.  This message to the Andorid system log is similar to the one posted to Firebase but can be viewed immediately with the Android Studio Logcat utility.
**Testing**:  
Create a Story Producer directory with the "002 Lost Coin.bloom" file.
Start Story Producer and  Story Producer will parse the  "002 Lost Coin.bloom"  and create the "002 Lost Coin" directory.  
Exit Story Producer and then  corrupt the "002 Lost Coin"/project/story.json file by inserting extraneous '}' characters into the file.  
Start Story Producer and Story Producer will process the corrupt story.json file, send a log message to Firebase, send an exception to Firebase and send a message to the Android system log.  View the results in Firebase and the Android system log.
This was tested on Android 11 with a Pixel 5.