### PR TITLE
Issue #555: Create backup file for exceptions & add fields to story.json

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/model/Story.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Story.kt
@@ -1,10 +1,15 @@
 package org.sil.storyproducer.model
 
 
+import android.os.Build
 import com.squareup.moshi.JsonClass
-import org.sil.storyproducer.R
+import org.sil.storyproducer.BuildConfig
 import org.sil.storyproducer.model.logging.LogEntry
+import java.text.SimpleDateFormat
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.*
+
 
 internal const val PROJECT_DIR = "project"
 internal const val VIDEO_DIR = "videos"
@@ -15,7 +20,19 @@ internal val RE_FILENAME = "([^|]+[|])?(.*)".toRegex()
 
 @JsonClass(generateAdapter = true)
 class Story(var title: String, var slides: List<Slide>){
+    // DKH - Updated 06/02/2021  for Issue 555: Report Story Parse Exceptions and Handle them appropriately
+    // Record versionCode & versionName which come from build.gradle (Module: StoreyProducer.app)
+    // Record timeStamp for when story.json file was written
+    // This will allow future Story Producer Apps to be backwards compatibility with old stories
+    // This will also allow for debugging of stories that have parse errors
 
+    // These are the initial story default values and will be updated from a story.json file if
+    // function storyFromJason is called and the story.json file contains these fields
+    // These values are also updated from function "Story.ToJason" when it is time to
+    // update the story.json file
+    var storyToJasonAppVersionCode = 0  // default value - no value available
+    var storyToJasonAppVersionName = "" // default value - no value available
+    var storyToJasonTimeStamp = ""  // default value - no value available
     var isApproved: Boolean = false
     var learnAudioFile = ""
     var wholeStoryBackTAudioFile = ""

--- a/app/src/main/java/org/sil/storyproducer/model/Story.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Story.kt
@@ -33,6 +33,7 @@ class Story(var title: String, var slides: List<Slide>){
     var storyToJasonAppVersionCode = 0  // default value - no value available
     var storyToJasonAppVersionName = "" // default value - no value available
     var storyToJasonTimeStamp = ""  // default value - no value available
+
     var isApproved: Boolean = false
     var learnAudioFile = ""
     var wholeStoryBackTAudioFile = ""

--- a/app/src/main/java/org/sil/storyproducer/model/StoryIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/StoryIO.kt
@@ -64,7 +64,7 @@ fun Story.toJson(context: Context){
 fun storyFromJson(context: Context, storyTitle: DocumentFile): Story?{
     val filePath = "$PROJECT_DIR/$PROJECT_FILE"  // location of file
     var fileContents: String? = null
-    // var fileContents: String? = null
+
     try {
         // use Moshi to restore all information associated with this story
         val moshi = Moshi


### PR DESCRIPTION
**Problem:** The story.jason file is not saved during parse error which causes loss of data

**Solution:** Save the story.jason file to a backup file and add new data fields to the story.jason file that includes a file write timestamp, Story Producer app version name (string)  and Story Producer app version code (integer).

**Test 1:** Create a Story Producer directory with the "002 Lost Coin.bloom" file. Start Story Producer and  Story Producer will parse the  "002 Lost Coin.bloom"  and create the "002 Lost Coin/project" directory.  Exit Story Producer and see if the story.json file in "002 Lost Coin/project" includes the new fields. 

**Expected:** The following new fields are in the story.json file: storyToJasonAppVersionCode, storyToJasonAppVersionName and storyToJasonTimeStamp 

**Test 2:**  Corrupt the "002 Lost Coin/project/story.json" file by inserting extraneous '}' characters into the file.  

**Expected:**   Start Story Producer and Story Producer will process the corrupt story.json file and create a backup file in the directory  "002 Lost Coin/project/" called storyWithParseErr_yyyy-mm-dd-hh-mm-ss.json where yyyy is the year, mm is the month, dd is the day, hh is the hour, and ss is the seconds (e.g.: storyWithParseErr_2021-06-04-17-19-58.json). This backup file contains the corrupted contents of the original story.json file.  A new story.json file is also created that is properly formatted.