### PR TITLE
Sp 407 story filter for baseline 3.0.6

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
@@ -83,13 +83,21 @@ open class BaseActivity : AppCompatActivity(), BaseActivityView {
     }
     // DKH - 05/12/2021
     // Issue #573: SP will hang/crash when submitting registration
-    // showRegistration Argument allows calling function in current Activity to terminate the
-    // current Activity and then show the Registration screen via the RegistrationActivity
-    // Any MainActivity function should set executeFinishActivity to false.  MainActivity should
-    // always exist.
-    // Activities like LearnActivity will exit by using the default value of true
+    //
+    // showRegistration Argument allows the caller in the current Activity to finish or
+    // not finish the current Activity before starting the RegistrationActivity.
+    // The MainActivity should set executeFinishActivity to false so that when the registration
+    // is complete, there is a Story Producer activity that will control execution.
     // After the RegistrationActivity completes, control is returned to the MainActivity
     // where the list of story templates are displayed
+    //
+    // 06/14/2021 - DKH, Issue 407, Pull Request 561 - Merge into Latest sillsdev
+    // Updated selectItem in DrawerItemclickListener to set Workspace.showRegistration
+    // to true and then call showMain() instead of calling showRegistration.  This is equivalent
+    // to calling showRegistration.  See selectItem for more detail.
+    //
+    // All showRegistration calls should be done through the MainActivity to
+    // avoid hanging Story Producer.
     override fun showRegistration(executeFinishActivity: Boolean) {
         startActivity(Intent(this, RegistrationActivity::class.java))
 

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -15,11 +15,16 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
+import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.sil.storyproducer.R
 import org.sil.storyproducer.activities.BaseActivity
+import org.sil.storyproducer.controller.storylist.StoryPageAdapter
+import org.sil.storyproducer.controller.storylist.StoryPageTab
 import org.sil.storyproducer.model.Phase
 import org.sil.storyproducer.model.PhaseType
 import org.sil.storyproducer.model.Story
@@ -30,9 +35,9 @@ import java.io.Serializable
 
 class MainActivity : BaseActivity(), Serializable {
 
-    lateinit var storyList: StoryListFrag
-
     private var mDrawerLayout: DrawerLayout? = null
+    lateinit var storyPageViewPager : ViewPager2
+    lateinit var storyPageTabLayout : TabLayout
 
     private val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -51,9 +56,10 @@ class MainActivity : BaseActivity(), Serializable {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        storyList = StoryListFrag()
         setContentView(R.layout.activity_main)
         setupDrawer()
+        setupStoryListTabPages()
+
 
         if (!Workspace.isInitialized) {
             initWorkspace()
@@ -74,12 +80,18 @@ class MainActivity : BaseActivity(), Serializable {
             // the story template list
             showRegistration(false)
         }
+        // DKH - 07/10/2021 - Issue 407: Add filtering to SP's 'Story Templates' List
+        // Updated while integrating pull request #561 into current sillsdev baseline
+        // This was deleted in pull request #561.
+        // It was added back in because it monitors the network connection for VolleySingleton
+        // and is used by  for support of RemoteCheckFrag.java,
+        // AudioUpload.java & BackTranslationUpload.java
         GlobalScope.launch {
             runOnUiThread {
-                supportFragmentManager.beginTransaction().add(R.id.fragment_container, storyList).commit()
                 this@MainActivity.applicationContext.registerReceiver(receiver, IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION))
             }
         }
+
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -94,6 +106,7 @@ class MainActivity : BaseActivity(), Serializable {
         Workspace.activeStory = story
         val intent = Intent(this.applicationContext, Workspace.activePhase.getTheClass())
         startActivity(intent)
+        finish()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -121,6 +134,33 @@ class MainActivity : BaseActivity(), Serializable {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        storyPageViewPager.unregisterOnPageChangeCallback(storyPageChangeCallback)
+    }
+
+    var storyPageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+        override fun onPageSelected(position: Int) {
+            Log.i("MainActivity Story Page", "Selected Tab: $position")
+        }
+    }
+
+    private fun setupStoryListTabPages() {
+        storyPageViewPager = findViewById(R.id.storyPageViewPager)
+        storyPageViewPager.offscreenPageLimit = StoryPageTab.values().size
+        storyPageTabLayout = findViewById(R.id.tabLayout)
+
+        val storyPageAdapter = StoryPageAdapter(this, StoryPageTab.values().size)
+        storyPageViewPager.adapter = storyPageAdapter
+
+        storyPageViewPager.registerOnPageChangeCallback(storyPageChangeCallback)
+
+        // Sets the Tab Names from the list of StoryPageTabs
+        TabLayoutMediator(storyPageTabLayout, storyPageViewPager) { tab, position ->
+            tab.text = getString(StoryPageTab.values()[position].nameId)
+        }.attach()
     }
 
     /**
@@ -154,7 +194,9 @@ class MainActivity : BaseActivity(), Serializable {
             }
             R.id.nav_demo -> {
                 Workspace.addDemoToWorkspace(this)
-                storyList.notifyDataSetChanged()
+
+                // Refresh all the stories in the story page tabs
+                setupStoryListTabPages()
             }
 
             R.id.nav_stories -> {

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
@@ -1,0 +1,49 @@
+package org.sil.storyproducer.controller.storylist
+
+import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Story
+import org.sil.storyproducer.model.Workspace
+
+/**
+ * Contains all of the Filter Options for the main toolbar. To add a new filter option to the story
+ * menu, create a new string with the title and add it to /res/value/strings.xml. Next, add the
+ * types of stories that should be applied when the option is clicked
+ *
+ * Example:
+ *
+ * Film(R.string.film_toolbar) {
+ *  override fun getStoryList(): List<Story> {
+ *
+ *  // Tells what stories should be added when clicked
+ *      return Workspace.Stories.filter { story ->
+ *          story.isFilmStory
+ *      }
+ *  }
+ */
+enum class FilterOptions(val nameId: Int) {
+    OT(R.string.ot_toolbar) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter { story ->
+                story.type == Story.StoryType.OLD_TESTAMENT
+            }
+        }
+    },
+
+    NT(R.string.nt_toolbar) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter { story ->
+                story.type == Story.StoryType.NEW_TESTAMENT
+            }
+        }
+    },
+
+    Other(R.string.other_toolbar) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter { story ->
+                story.type == Story.StoryType.OTHER
+            }
+        }
+    };
+
+    abstract fun getStoryList() : List<Story>
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
@@ -21,6 +21,34 @@ import org.sil.storyproducer.model.Workspace
  *  }
  */
 enum class FilterOptions(val nameId: Int) {
+    // DKH - 07/09/2021
+    // These options show up on the "Story Template" list when the "ALL STORIES" tab is selected.
+    // The Story Template list for all the tabs (ALL STORIES, IN PROGRESS, COMPLETED) are
+    // grouped/sorted by the numeric string that precedes at title, eg: "002 Lost Coin" followed by
+    // "006 Snakes Secret"
+    // Currently, the three subcategories for the "ALL STORIES" tab are listed
+    // below as enums (Other, OT, NT).  To keep with the paradigm of displaying the
+    // "Story Template" list sorted by the numeric string at the beginning of the title,
+    // (eg, 002 in title "002 Lost Coin") we have to match the enum values with the numeric
+    // sort order that we want.  Here is the table
+    //  ENUM            Subcategory Type            Range of values
+    //    0                 Other                       0-99
+    //    1                   OT                       100-199
+    //    2                   NT                       200-299
+    //
+    //  If you set NT as enum 1 and OT as enum 2, when enabling or disabling the subcategories,
+    //  the list will appear out of order, ie, the 200-299 range will appear before the 100-199.
+    //
+    // These names "Other", "OT" & "NT" are define in strings.xml
+
+    Other(R.string.other_toolbar) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter { story ->
+                story.type == Story.StoryType.OTHER
+            }
+        }
+    },
+
     OT(R.string.ot_toolbar) {
         override fun getStoryList(): List<Story> {
             return Workspace.Stories.filter { story ->
@@ -35,15 +63,9 @@ enum class FilterOptions(val nameId: Int) {
                 story.type == Story.StoryType.NEW_TESTAMENT
             }
         }
-    },
-
-    Other(R.string.other_toolbar) {
-        override fun getStoryList(): List<Story> {
-            return Workspace.Stories.filter { story ->
-                story.type == Story.StoryType.OTHER
-            }
-        }
     };
+
+
 
     abstract fun getStoryList() : List<Story>
 }

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterOptions.kt
@@ -21,7 +21,10 @@ import org.sil.storyproducer.model.Workspace
  *  }
  */
 enum class FilterOptions(val nameId: Int) {
-    // DKH - 07/09/2021
+    // DKH - 07/10/2021 - Issue 407: Add filtering to SP's 'Story Templates' List
+    // Updated while integrating pull request #561 into current sillsdev baseline
+    // Integration testing identified the stories in the displayed list were out of order
+    //
     // These options show up on the "Story Template" list when the "ALL STORIES" tab is selected.
     // The Story Template list for all the tabs (ALL STORIES, IN PROGRESS, COMPLETED) are
     // grouped/sorted by the numeric string that precedes at title, eg: "002 Lost Coin" followed by

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterToolbarFrag.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/FilterToolbarFrag.kt
@@ -1,0 +1,60 @@
+package org.sil.storyproducer.controller.storylist
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Story
+
+/**
+ * FilterToolbarFrag is the child filter element that is contained in a StoryListFragment.
+ * The FilterToolbarFrag dynamically generates a list of Material.io Choice Chips from FilterOptions.
+ * These Chips are clickable buttons that notify the parent StoryListFragment when they are clicked
+ * causing a new update of the story list in the StoryListFragment ListAdapter.
+ */
+class FilterToolbarFrag(private val storyPageFrag : StoryPageFragment): Fragment() {
+
+    private lateinit var filterChipGroup : ChipGroup
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        val toolbarView = inflater.inflate(R.layout.filter_toolbar, container, false)
+
+        filterChipGroup = toolbarView.findViewById(R.id.filter_group)
+
+        // Create all the Chips dynamically
+        FilterOptions.values().forEach { option ->
+            val chip = inflater.inflate(R.layout.filter_chip_choice, filterChipGroup, false) as Chip
+            chip.text = getString(option.nameId)
+            chip.id = option.ordinal
+            filterChipGroup.addView(chip)
+
+            // Apply listeners to each of the Chips
+            chip.setOnCheckedChangeListener { _, _ ->
+                registerFilterChanged()
+            }
+        }
+
+        return toolbarView
+    }
+
+    private fun registerFilterChanged() {
+        var newStoryList = mutableListOf<Story>()
+
+        filterChipGroup.checkedChipIds.forEach { id ->
+            val filterStoryList = FilterOptions.values()[id].getStoryList()
+            newStoryList.addAll(filterStoryList)
+        }
+
+        // Remove all duplicate values
+        newStoryList = newStoryList.distinct().toMutableList()
+
+        // Update parent fragment with generated story list
+        storyPageFrag.updateStoryList(newStoryList)
+    }
+
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageAdapter.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageAdapter.kt
@@ -1,0 +1,17 @@
+package org.sil.storyproducer.controller.storylist
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class StoryPageAdapter(activity: AppCompatActivity, private val itemsCount: Int) :
+        FragmentStateAdapter(activity) {
+
+    override fun getItemCount(): Int {
+        return itemsCount
+    }
+
+    override fun createFragment(position: Int): Fragment {
+        return StoryPageFragment.getInstance(position)
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageFragment.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageFragment.kt
@@ -1,0 +1,186 @@
+package org.sil.storyproducer.controller.storylist
+
+import android.app.Activity
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.text.Html
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.*
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+import org.sil.storyproducer.R
+import org.sil.storyproducer.activities.BaseActivity
+import org.sil.storyproducer.controller.MainActivity
+import org.sil.storyproducer.model.Story
+import org.sil.storyproducer.service.SlideService
+
+/**
+ * StoryPageFragment is a flexible fragment in that it displays different things based on the
+ * current configurations. Typically, this shows a list of list of stories. However, when there are
+ * no stories present, a message is shown that notifies the user that there aren't any stories of
+ * that type in the tab. Lastly, a StoryPageFragment can contain a FilterToolbarFrag that helps to
+ * sort the list of stories in the adapter.
+ *
+ * StoryPageFragment has a one-one relationship with a StoryPageTab, however, since the
+ * StoryPageFragment is an Android:Fragment, it will follow the typical activity lifecycle, which
+ * means that it gets created and destroyed when it is not being used.
+ */
+class StoryPageFragment : Fragment() {
+
+    private lateinit var storyPageTab : StoryPageTab
+    private lateinit var listView: ListView
+    private lateinit var adapter: ListAdapter
+
+    companion object {
+        const val ARG_POSITION = "position"
+
+        /**
+         * Creates a new instance based off of the tab position parameter
+         * @param position The Tab Position
+         */
+        fun getInstance(position: Int): StoryPageFragment {
+            val storyPageFragment = StoryPageFragment()
+            val bundle = Bundle()
+            bundle.putInt(ARG_POSITION, position)
+            storyPageFragment.arguments = bundle
+            return storyPageFragment
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        super.onCreate(savedInstanceState)
+
+        val position = requireArguments().getInt(ARG_POSITION)
+        storyPageTab = StoryPageTab.values()[position]
+
+        if (storyPageTab.getStoryList().isEmpty()) {
+            val view = inflater.inflate(R.layout.fragment_no_stories, container, false)
+
+            view!!.findViewById<TextView>(R.id.stories_not_found_text).text =
+                    if (Build.VERSION.SDK_INT >= 24){
+                        Html.fromHtml(getString(storyPageTab.emptyStoryStringId), 0)}
+                    else{
+                        Html.fromHtml(getString(storyPageTab.emptyStoryStringId))}
+
+            val button : Button = view.findViewById(R.id.update_workspace_button)
+            if(storyPageTab != StoryPageTab.ALL_STORIES) {
+                button.visibility = View.INVISIBLE
+            } else {
+                button.setOnClickListener {
+                    (activity as? BaseActivity)?.showSelectTemplatesFolderDialog()
+                }
+            }
+
+            return view
+        }
+
+        val lfview = inflater.inflate(R.layout.story_list_container, container, false)
+
+        // Apply the Stories to the Story List View
+        adapter = ListAdapter(context!!, R.layout.story_list_item, storyPageTab.getStoryList(), storyPageTab)
+
+        listView = lfview.findViewById(R.id.story_list_view)
+
+        listView.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
+            (activity as MainActivity).switchToStory(storyPageTab.getStoryList()[position])
+        }
+
+        // Assign adapter to ListView
+        listView.adapter = adapter
+
+        return lfview
+    }
+
+    /**
+     * Updates ListAdapter to use the newly provided list. This is very helpful when filter options
+     * are used.
+     * @param storyList List of new stories to be used in the ListAdapter
+     */
+    fun updateStoryList(storyList: List<Story>) {
+        adapter = ListAdapter(context!!, R.layout.story_list_item, storyList, storyPageTab)
+        listView.adapter = adapter
+        adapter.notifyDataSetChanged()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        if(storyPageTab.hasFilterToolbar && storyPageTab.getStoryList().isNotEmpty()) {
+            val childFragment: Fragment = FilterToolbarFrag(this)
+            val transaction: FragmentTransaction = childFragmentManager.beginTransaction()
+            transaction.replace(R.id.filter_container, childFragment).commit()
+        }
+    }
+
+}
+
+class ListAdapter(context: Context,
+                  private val resourceId: Int,
+                  private val stories: List<Story>,
+                  private val storyPageTab: StoryPageTab) : ArrayAdapter<Story>(context, resourceId, stories) {
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        var row = convertView
+        val holder: FileHolder
+
+        if (row == null) {
+            val inflater = (context as Activity).layoutInflater
+            row = inflater.inflate(resourceId, parent, false)
+
+            holder = FileHolder(row!!)
+            row.tag = holder
+        } else {
+            holder = row.tag as FileHolder
+        }
+
+        if(position <= stories.size){
+            val story = stories[position]
+            holder.txtTitle.text = story.title
+            //TODO put th number 25 in some configuration.  What if the images are different sizes?
+            //Use the "second" image, because the first is just for the title screen.
+            holder.imgIcon.setImageBitmap(SlideService(context).getImage(1, 25, story))
+            holder.txtSubTitle.text = story.slides[0].subtitle
+
+            // Handle graying out text when story is completed
+            if(storyPageTab == StoryPageTab.ALL_STORIES && story.isComplete) {
+                holder.txtTitle.alpha = 0.5f
+                holder.txtSubTitle.alpha = 0.5f
+            } else {
+                holder.txtTitle.alpha = 1f
+                holder.txtSubTitle.alpha = 1f
+            }
+
+            // Handle the image icon to the side of the story
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                    && storyPageTab == StoryPageTab.ALL_STORIES) { // Only show icon on ALL Stories
+
+                val color = if(story.isComplete) {
+                    R.color.story_list_completed
+                } else if(story.inProgress && !story.isComplete) {
+                    R.color.story_list_in_progress
+                } else {
+                    null
+                }
+
+                val progressIcon : ImageView = row.findViewById(R.id.progress_icon)
+
+                if(color == null) {
+                    progressIcon.visibility = View.INVISIBLE
+                } else {
+                    progressIcon.visibility = View.VISIBLE
+                    progressIcon.setBackgroundColor(context.getColor(color))
+                }
+            }
+        }
+
+        return row
+    }
+
+    internal class FileHolder(view: View){
+        var imgIcon: ImageView = view.findViewById(R.id.story_list_image)
+        var txtTitle: TextView = view.findViewById(R.id.story_list_title)
+        var txtSubTitle: TextView = view.findViewById(R.id.story_list_subtitle)
+    }
+
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageTab.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/storylist/StoryPageTab.kt
@@ -1,0 +1,42 @@
+package org.sil.storyproducer.controller.storylist
+
+import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Story
+import org.sil.storyproducer.model.Workspace
+
+/**
+ * Contains all of the tabs that are added to the main page. This has been created such that if you
+ * want to add another tab, all you need to do is edit this file and it will dynamically appear on
+ * the story list page. There is a one-one correlation between the enum values below and a
+ * StoryPageFragment.
+ */
+enum class StoryPageTab(val nameId: Int,
+                        val emptyStoryStringId: Int,
+                        val hasFilterToolbar : Boolean) {
+
+    ALL_STORIES(R.string.all_stories_tab, R.string.stories_not_found_body, true) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories
+        }
+    },
+
+    IN_PROGRESS(R.string.in_progress_tab, R.string.stories_not_found_in_progress, false) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter {
+                story -> story.inProgress && !story.isComplete
+            }
+        }
+    },
+
+    COMPLETED(R.string.completed_tab, R.string.stories_not_found_completed, false) {
+        override fun getStoryList(): List<Story> {
+            return Workspace.Stories.filter {
+                story -> story.isComplete
+            }
+        }
+    };
+
+    // Allow the story list to be dynamically generated each time
+    // this allows the story to be updated
+    abstract fun getStoryList() : List<Story>
+}

--- a/app/src/main/java/org/sil/storyproducer/model/Story.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Story.kt
@@ -19,7 +19,14 @@ internal val RE_DISPLAY_NAME = "([^|]+)[|.]".toRegex()
 internal val RE_FILENAME = "([^|]+[|])?(.*)".toRegex()
 
 @JsonClass(generateAdapter = true)
+
 class Story(var title: String, var slides: List<Slide>){
+
+    // DKH - 6/7/2021 Merge conflict resolution (next 3 lines placed here) - needed for Issue 407 (Story Filter)
+    enum class StoryType {
+        OLD_TESTAMENT, NEW_TESTAMENT, OTHER;
+    }
+
     // DKH - Updated 06/02/2021  for Issue 555: Report Story Parse Exceptions and Handle them appropriately
     // Record versionCode & versionName which come from build.gradle (Module: StoreyProducer.app)
     // Record timeStamp for when story.json file was written
@@ -43,6 +50,33 @@ class Story(var title: String, var slides: List<Slide>){
     var lastSlideNum: Int = 0
     var importAppVersion = ""
     var localCredits = ""
+
+    val inProgress: Boolean get() {
+        for(slide in slides){
+            if(slide.translateReviseAudioFiles.isNotEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    val isComplete: Boolean get() {
+        return outputVideos.isNotEmpty()
+    }
+
+    val type : StoryType get() {
+        return try {
+            // Get number from story
+            when (title.split("")[1].toInt()) {
+                0 -> StoryType.OTHER
+                1 -> StoryType.OLD_TESTAMENT
+                2 -> StoryType.NEW_TESTAMENT
+                else -> StoryType.OTHER
+            }
+        } catch(e : NumberFormatException) {
+            StoryType.OTHER
+        }
+    }
 
     val shortTitle: String get() {
         val match = RE_TITLE_NUMBER.find(title)

--- a/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
@@ -24,7 +24,23 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 activity.finish()
             }
             1 -> {
-                activity.showRegistration()
+                // 06/14/2021 - DKH, Issue 407, Pull Request 561 - Merge into Latest sillsdev
+                // The new Filter layout for the Story Templates broke the capability to launch
+                // the showRegistration () from the calling activity.  SP uses the paradigm of
+                // always finishing an activity and then moving onto the next activity.  In this case
+                // it would be to finish the current activity and move on to the
+                // Registration Activity.  However, when a submit is
+                // done from registration, another application such as WhatsApp or Messenger takes
+                // over and when they finished, they exit without starting another SP activity.
+                // This causes SP to hang in the Splash Activity with no where to go.  This is
+                // similar to the issue fixed in
+                // Issue #573: SP will hang/crash when submitting registration
+                // In that fix, the Main activity does not finish before starting the registration
+                // activity.  So, employ the same fix, ie, tell the main activity to display the
+                // registration when the main activity is started and then start the main activity
+                // See comments in MainActivity for more details
+                Workspace.showRegistration = true
+                activity.showMain()
             }
             2 -> {
                 activity.showSelectTemplatesFolderDialog()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,23 +20,22 @@
             android:maxHeight="?android:attr/actionBarSize"
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container"
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:clickable="true"
-            android:focusable="true">
+            android:orientation="vertical">
 
-            <ProgressBar
-                android:id="@+id/indeterminateBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:visibility="gone"
-                />
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/storyPageViewPager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
 
-        </FrameLayout>
+        </LinearLayout>
     </LinearLayout>
 
     <com.google.android.material.navigation.NavigationView

--- a/app/src/main/res/layout/filter_chip_choice.xml
+++ b/app/src/main/res/layout/filter_chip_choice.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:theme="@style/FilterToolbarChips"
+    style="@style/Widget.MaterialComponents.Chip.Filter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:checked="true" />

--- a/app/src/main/res/layout/filter_toolbar.xml
+++ b/app/src/main/res/layout/filter_toolbar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:theme="@style/FilterToolbarChips">
+
+    <com.google.android.material.chip.ChipGroup xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/filter_group"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp"
+        app:singleSelection="false">
+        <!-- List Chips from filter_chip_choice.xml -->
+    </com.google.android.material.chip.ChipGroup>
+
+</LinearLayout>

--- a/app/src/main/res/layout/story_list_container.xml
+++ b/app/src/main/res/layout/story_list_container.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/filter_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:clickable="true"
+        android:focusable="true"/>
+
+    <ListView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/story_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal" />
+</LinearLayout>

--- a/app/src/main/res/layout/story_list_item.xml
+++ b/app/src/main/res/layout/story_list_item.xml
@@ -1,40 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="72dp">
+
     <ImageView
         android:id="@+id/story_list_image"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:background="@color/white"
-        android:layout_centerVertical="true"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="center_horizontal|center_vertical"
         android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:background="@color/white"
         android:contentDescription="@string/story_picture" />
 
-    <TextView
-        android:id="@+id/story_list_title"
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="@dimen/text_title"
-        android:text="Replace with Title"
-        android:layout_marginStart="72dp"
-        android:layout_marginTop="@dimen/activity_horizontal_margin"
-        android:textColor="@color/white"
-        tools:ignore="HardcodedText" />
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        android:gravity="start|center_vertical"
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/story_list_subtitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_title_sub"
-        android:text="Replace with subtitle"
-        android:layout_marginStart="72dp"
-        android:layout_marginBottom="@dimen/activity_horizontal_margin"
-        android:layout_below="@+id/story_list_title"
-        tools:ignore="HardcodedText" />
+        <TextView
+            android:id="@+id/story_list_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="Replace with Title"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_title"
+            tools:ignore="HardcodedText" />
 
-</RelativeLayout>
+        <TextView
+            android:id="@+id/story_list_subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="Replace with subtitle"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_title_sub"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/progress_icon"
+        android:layout_width="8dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center|right|end"
+        android:layout_marginTop="5dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginBottom="5dp"
+        android:background="@color/story_list_in_progress"
+        android:baselineAlignBottom="false"
+        android:clickable="false"
+        android:visibility="invisible"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,4 +25,7 @@
     <color name="remote_check_phase">#551a8b</color>
     <color name="messagingBkrd">#8e8e93</color>
     <color name="messagingSecondary">#ceced2</color>
+
+    <color name="story_list_in_progress">@color/primary</color>
+    <color name="story_list_completed">@color/darkGray</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,8 @@
         for story templates does not contain usable templates.  Select the appropriate
         \'&lt;font color=\"green\">&lt;b>SP Templates&lt;/b>&lt;/font>\' folder - normally found on the
         &lt;font color=\"green\">&lt;b>SD card&lt;/b>&lt;/font>.</string>
+    <string name="stories_not_found_in_progress">There are no stories in progress.</string>
+    <string name="stories_not_found_completed">There are no completed stories.</string>
     <string name="welcome_screen_select_template_folder">
         Story Producer is different from typical apps.
         You must first create a folder on your SD card (preferred) where the story template files must be downloaded by you.&lt;br>
@@ -263,6 +265,17 @@
     <string name="update_workspace">Select \'SP Templates\' folder</string>
     <string name="cancelling">Cancelling &#8230;</string>
     <string name="copy_demo">Add demo to story list</string>
+
+    <!-- Main Story Page -->
+    <string name="all_stories_tab">All Stories</string>
+    <string name="in_progress_tab">In Progress</string>
+    <string name="completed_tab">Completed</string>
+
+    <!-- Filter Toolbar -->
+    <string name="film_toolbar">Film</string>
+    <string name="nt_toolbar">NT</string>
+    <string name="ot_toolbar">OT</string>
+    <string name="other_toolbar">Other</string>
 
     <!-- About -->
     <string name="about">About</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,4 +17,11 @@
         <item name="android:padding">0dp</item>
     </style>
 
+    <style name="FilterToolbarChips" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+        <item name="android:checkable">true</item>
+        <item name="chipIconVisible">false</item>
+        <item name="closeIconVisible">false</item>
+        <item name="checkedIcon">@drawable/ic_mtrl_chip_checked_black</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
**Problem:** For issue #407, "Add filtering to SP's 'Story Templates' List", the pull request #561 was submitted by Cedarville Students. The pull request #561 did not have the latest changes from the sillsdev baseline.

**Solution:** Merge #561 into the latest sillsdev baseline incorporating all the latest sillsdev changes and do nominal checkout of the merged baseline along with functional checkout of the new capabilities.

**Testing Problems:** The following problems were identified and fixed during integration testing checkout:

- Changes in issue 561 turnover broke the registration process. The same fix that was identified in issue 573 (pull Issue #573: SP hangs on Registration Submit #582) was reused. (see SHA1: 19920750e9)
- The 561 pull deleted some network code used in remote checking. The code was added back in (see SHA1: 1b88be4e)
- During checkout of the new filter functionality, sometimes the stories would be out of order when selecting filters. This was fixed in SHA1: 50c831983
- During checkout of the new filter functionality, the story displayed did not match the selected story. The fix is in SHA1: bf70992ac0d

**Testing Scenario**:  Twelve stories were loaded, 4 from each category (OT,NT,OTHER) and then 6 stories were advanced into the "in progress" category.   Three stories were then advanced into "Completed category".  Registration was updated from the Story Templates display and also from the "Learn Phase".  

Scenario was run  from Android Studio on Android 11 using Pixel 5 hardware with a Android Studio debug executable.  **_All Tests passed._**

Scenario was run  from Android Studio on Android 9 using a Pixel 2 emulator with Team City build 286 executable.  **_All Tests passed._**