### PR TITLE
Sp 166 word links 3.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ The Espresso tests make a couple of assumptions about the state of the emulator/
 6. The "Run" tool window shows the results of the tests.
 *Note:* If no tests appear in the "Run" window, you may need to toggle the visibility of passing tests. Currently, the toggle button looks like green checkmark inside of a circle.
 
+## Word Links (WL)
+* WLs are imported in the workspace, wordlinks/wordlinks.csv is read from the workspace path

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,11 @@ dependencies {
     implementation 'net.lingala.zip4j:zip4j:2.3.1'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    // DKH - 08/26/2021 Added by Cedarville for Wordlinks
+    // implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+    // Issue 166, Cedarville pull #519
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+
     kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.6.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,15 @@
             android:name=".controller.export.ShareActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="stateHidden" />
+        <!-- WordLinks -->
+        <activity
+            android:name=".controller.wordlink.WordLinksActivity"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
+        <!-- WordLinks List -->
+        <activity
+            android:name=".controller.wordlink.WordLinksListActivity"
+            android:screenOrientation="portrait" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/word_links.html
+++ b/app/src/main/assets/word_links.html
@@ -1,0 +1,226 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<title></title>
+	<meta name="generator" content="LibreOffice 6.2.1.2 (Linux)"/>
+	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
+	<meta name="changed" content="2019-04-02T16:55:08.972750319"/>
+	<style type="text/css">
+		@page { size: 8.5in 11in; margin: 0.79in }
+		p { margin-bottom: 0.1in; background: transparent; line-height: 115%; background: transparent }
+		h3 { margin-top: 0.1in; margin-bottom: 0.08in; background: transparent; line-height: 100%; background: transparent; page-break-after: avoid }
+		h3.western { font-family: "Liberation Serif", serif; font-size: 14pt; font-weight: bold }
+		h3.cjk { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
+		h3.ctl { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
+	</style>
+</head>
+<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><h3 class="western" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-before: always">
+	<font face="Arial, serif">Word Links</font>
+</h3>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Who</b></u></font></font><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">:
+</span></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Translators
+</b></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">and
+</span></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Accuracy
+checkers</b></font></font></span><span style="text-decoration: none">
+</span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">will
+find this tool or feature helpful to utilize.</span></font></font></span></font></font></font></p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Purpose</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:
+		The purpose of the Word Links tool is to provide </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>convenient
+		access </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">to
+		key terms across all the stories and to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>build
+		a database </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">of
+		audioized</font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">local
+		language renderings for key terms in a single location. And to assist
+		translators to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>render
+		Biblical key terms consistently</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">and
+		to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>pronounce
+		people and place names consistently</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">in/across
+		all the stories. Also, to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>provide
+		literal text back-translations</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">for
+		all key terms (and transliterations of names) as another means to
+		help an Accuracy Checker in their work.</font></font></font></font></font></p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Activities</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:</font></font></font></font></font></p>
+<ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>From
+			the sidebar menu, Word Links list: </b></font></font></font>
+	</p>
+		<ul>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Type
+					in the search bar to find a specific key term or name, or scroll
+					through the alphabetized terms to find what you are looking for.</font></font></font></p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
+					a word/name to open the Key Term popup window for that term.</font></font></font></p>
+		</ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Tap
+			a hyperlinked term</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">from
+			the TRANSLATE or ACCURACY CHECK phase, text section of each slide.</font></font></font></font></font></p>
+		<ul>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">A
+				</font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>blue
+					hyperlink</u></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">indicates
+					that there is no audio rendering for that term. Tapping a blue
+					hyperlink will navigate the user to the research screen for the
+					term.</font></font></font></font></font></p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">A
+				</font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>clear
+					hyperlink</u></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">(underlined
+					normal text) indicates that an audio rendering (at least one) has
+					been made for that term. Tapping a clear hyperlink will navigate
+					the user to the audio and text documentation screen for the term.
+					Slide up to see the research screen.</font></font></font></font></font></p>
+		</ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Read
+			and research</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">the
+			meaning of a term. </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Discuss
+		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">how
+			to render the term in the context of the story in the local
+			language. </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Consider
+		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">other
+			related but different terms.</font></font></font></font></font></p>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Document
+			a local language key term</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
+		</font></font></font></font></font>
+	</p>
+		<ul>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
+					the mic button at the bottom of the screen to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>record
+				</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">an
+					audio translation of the term in the local language. Tap the square
+					button to stop the recording. </font></font></font></font></font>
+			</p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
+					inside the companion text box to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>type
+				</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">a
+					word-for-word literal back translation in the source language (LWC)
+					of the audio rendering for the key term. Or, if a name was
+					recorded, type a (phonetic) transliteration of the word.</font></font></font></font></font></p>
+		</ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Recall
+			how a term was rendered. </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
+			a clear hyperlink to open the Key Term popup window, documentation
+			screen. Tap the triangle play button to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>listen
+		</u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">to
+			how a name or term was rendered in another story. Exit the Word Link popup
+			window to resume translation work. </font></font></font></font></font>
+	</p>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Exit
+		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
+			Key Term Tracker popup window by tapping the X in the upper right
+			corner of the screen. Resume your translation and checking
+			activities. Or sometimes, tapping the back arrow on your phone will
+			put you back where you just came from.</font></font></font></font></font></p>
+</ul>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Notes</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:</font></font></font></font></font></p>
+<ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
+			The Word Links database notes are intended to be non-encyclopedic in nature -- just a few notes to give translators essential and basic meaning or background.  If there is an existing local language Scripture translation or Bible translation team, these should always be consulted so there is consistency in how terms and names are rendered in the stories.
+		</font></font></font></p>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Two
+			types of words are included in the Word Links database:</font></font></font></p>
+		<ul>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>Biblical</u></font></font>
+					<font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>key</u></font></font>
+					<font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>terms</u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
+						Some of these terms may have multiple senses depending on their
+						context. Translators may need to record multiple audio renderings
+						for one key term and discern which rendering to use in which
+						context. Multiple audio renderings might also need to be recorded
+						to document different forms of a term (e.g. verb form and noun
+						form)</font></font></font></font></font></p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>Names</u></font></font>
+					<font face="Arial, serif"><font size="2" style="font-size: 11pt">for
+						people and places. The primary purpose for recording an audio
+						rendering for names is to provide consistency in pronunciation
+						across all the stories.</font></font></font></font></font></p>
+		</ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">There
+			are several sections in the Word Links Tracker popup window Research
+			screen to aid the story translator in their decision for how to
+			render the term:</font></font></font></p>
+		<ul>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">The
+					hyperlinked word from the story followed by its various grammatical
+					forms. These will be at the top of the popup window in the red section. </font></font></font>
+			</p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Notes
+					-- brief definitions or background information.</font></font></font></p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Related
+					(but different) terms, hyperlinked -- to provide some material for
+					comparison and contrast, further research.</font></font></font></p>
+			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Example
+					renderings from other languages, back translated -- to provide
+					practical ideas for how story translators might want to translate
+					the term in their local language.</font></font></font></p>
+		</ul>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">The
+			recording bar at the bottom of the screen will expand into an
+			extended screen below the research screen once a recording has been
+			made for a key term. Once audio renderings have been recorded for a
+			term, they can be reviewed in this extended documentation screen --
+			the audio rendering in the local language can be listened to and the
+			associated back-translated text can be read. </font></font></font>
+	</p>
+	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
+			The Word Links local language database could be backed up on a regular basis.  The WordLinks folder is located in the root of the SP Templates directory which is usually stored on the SD card. For backup, copy the WordLinks directory to another drive or card.
+		</font></font></font>
+	</p>
+</ul>
+
+</p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
+		Word Links (Key Term) Database copyright and license:
+	</b>
+	</font></font></font>
+</p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
+		Word Links (Key Term) Database including back translation contributions from the
+		following languages: </font></font></font>
+</p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Daasanach
+		(D), Wolof (W), Guajajara (G), Kandas (K) and Ramoaaina (R)</font></font></font></p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+
+</p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">©
+		2019 Wycliffe Bible Translators, Inc.</font></font></font></p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+
+</p>
+<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Licensed
+		under the terms of a Creative Commons Attribution-ShareAlike 4.0
+		International license.</font></font></font></p>
+</body>
+</html>

--- a/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/activities/BaseActivity.kt
@@ -19,6 +19,7 @@ import org.sil.storyproducer.controller.RegistrationActivity
 import org.sil.storyproducer.controller.SelectTemplatesFolderController
 import org.sil.storyproducer.controller.SelectTemplatesFolderController.Companion.SELECT_TEMPLATES_FOLDER_REQUEST_CODES
 import org.sil.storyproducer.controller.SelectTemplatesFolderController.Companion.UPDATE_TEMPLATES_FOLDER
+import org.sil.storyproducer.controller.wordlink.WordLinksListActivity
 import org.sil.storyproducer.model.Workspace
 import org.sil.storyproducer.view.BaseActivityView
 import timber.log.Timber
@@ -105,6 +106,11 @@ open class BaseActivity : AppCompatActivity(), BaseActivityView {
         if(executeFinishActivity) {
             finish()
         }
+    }
+
+    fun showWordLinksList() {
+        startActivity(Intent(this, WordLinksListActivity::class.java))
+        finish()
     }
 
     override fun showReadingTemplatesDialog(controller: BaseController) {

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -198,7 +198,9 @@ class MainActivity : BaseActivity(), Serializable {
                 // Refresh all the stories in the story page tabs
                 setupStoryListTabPages()
             }
-
+            R.id.nav_word_link_list -> {
+                showWordLinksList()
+            }
             R.id.nav_stories -> {
                 // Current fragment
             }

--- a/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
@@ -1,6 +1,7 @@
 package org.sil.storyproducer.controller
 
 import android.Manifest
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
@@ -20,9 +21,9 @@ import androidx.core.content.res.ResourcesCompat
 import com.android.volley.Request
 import com.android.volley.Response
 import com.android.volley.toolbox.StringRequest
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.sil.storyproducer.R
 import org.sil.storyproducer.model.Workspace
 import org.sil.storyproducer.tools.Network.VolleySingleton
@@ -568,7 +569,8 @@ open class RegistrationActivity : AppCompatActivity() {
             this.finish()
             reg.putBoolean(EMAIL_SENT, true)
             reg.save(this)
-            Log.i("Finished sending email", "")
+	    // DKH - 8/26/2021  Log.i needs second argument for print out
+            Log.i("Finished sending email", "Mail Sent")
         } catch (ex: android.content.ActivityNotFoundException) {
             FirebaseCrashlytics.getInstance().recordException(ex)
             Toast.makeText(this,

--- a/app/src/main/java/org/sil/storyproducer/controller/SlidePhaseFrag.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/SlidePhaseFrag.kt
@@ -2,6 +2,8 @@ package org.sil.storyproducer.controller
 
 import android.media.MediaPlayer
 import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
 import android.view.*
 import android.widget.*
 import com.google.android.material.snackbar.Snackbar
@@ -33,6 +35,7 @@ abstract class SlidePhaseFrag : androidx.fragment.app.Fragment() {
 
 
     protected var slideNum: Int = 0 //gets overwritten
+    protected lateinit var slide: Slide
     protected lateinit var viewModel: SlideViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,6 +43,7 @@ abstract class SlidePhaseFrag : androidx.fragment.app.Fragment() {
         try {
             slideNum = this.arguments!!.getInt(SLIDE_NUM)
             viewModel = SlideViewModelBuilder(Workspace.activeStory.slides[slideNum]).build()
+            slide = Workspace.activeStory.slides[slideNum]
         } catch (ex: Exception) {
             Timber.e(ex)
         }
@@ -186,5 +190,33 @@ abstract class SlidePhaseFrag : androidx.fragment.app.Fragment() {
     }
 
     open fun onStartedSlidePlayBack() {}
+
+    /**
+     * Sets the main text of the layout.
+     * The text will be ran through and checked if any of the words are a wordlink.
+     * These matching strings will be turned into a link that can be clicked to open WordLinksActivity, showing the user more about the wordlink.
+     *
+     * @param textView The text view that will be filled with the verse's text.
+     */
+    protected fun setScriptureText(textView: TextView) {
+        val phrases = Workspace.WLSTree.splitOnWordLinks(slide.content)
+        textView.text = phrases.fold(SpannableStringBuilder()) {
+            result, phrase -> result.append(stringToWordLink(phrase, activity))
+        }
+        // this method provides cursor positioning, scrolling and text selection functionality
+        textView.movementMethod = LinkMovementMethod.getInstance()
+    }
+
+    protected fun setReferenceText(textView: TextView) {
+        val titleNamePriority = arrayOf(slide.reference, slide.subtitle, slide.title)
+        for (title in titleNamePriority) {
+            if (title != "") {
+                textView.text = title
+                return
+            }
+        }
+        //There is no reference text.
+        textView.text = ""
+    }
 
 }

--- a/app/src/main/java/org/sil/storyproducer/controller/accuracycheck/AccuracyCheckFrag.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/accuracycheck/AccuracyCheckFrag.kt
@@ -36,8 +36,8 @@ class AccuracyCheckFrag : SlidePhaseFrag() {
         return inflater.inflate(R.layout.fragment_accuracy_check, container, false)?.apply {
             this@AccuracyCheckFrag.rootView = this
             setPic(findViewById<View>(R.id.fragment_image_view) as ImageView)
-            findViewById<TextView>(R.id.fragment_reference_text).text = viewModel.scriptureReference
-            findViewById<TextView>(R.id.fragment_scripture_text).text = viewModel.scriptureText
+            setScriptureText(rootView!!.findViewById(R.id.fragment_scripture_text))
+            setReferenceText(rootView!!.findViewById(R.id.fragment_reference_text))
             setCheckmarkButton(findViewById<View>(R.id.concheck_checkmark_button) as ImageButton)
             setLogsButton(findViewById<View>(R.id.concheck_logs_button) as ImageButton)
         }

--- a/app/src/main/java/org/sil/storyproducer/controller/adapter/RecordingsListAdapter.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/adapter/RecordingsListAdapter.kt
@@ -13,6 +13,7 @@ import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 import org.sil.storyproducer.R
 import org.sil.storyproducer.controller.Modal
 import org.sil.storyproducer.model.PhaseType
@@ -144,7 +145,7 @@ class RecordingsListAdapter(val values: MutableList<String>?, private val listen
             slideNum = mSlideNum
         }
 
-        fun setParentFragment(parentFragment: androidx.fragment.app.Fragment){
+        fun setParentFragment(parentFragment: Fragment?){
             try{
                 playbackListener = parentFragment as RecordingToolbar.ToolbarMediaListener
             }
@@ -244,7 +245,11 @@ class RecordingsListAdapter(val values: MutableList<String>?, private val listen
         }
 
         override fun onDeleteClick(name: String, pos: Int){
-            deleteAudioFileFromList(context,pos)
+            if (Workspace.activePhase.phaseType == PhaseType.WORD_LINKS) {
+                deleteWLAudioFileFromList(context, pos)
+            } else {
+                deleteAudioFileFromList(context,pos)
+            }
             displayNames.removeAt(pos)
             recyclerView?.adapter!!.notifyDataSetChanged()
             if ("${Workspace.activeDir}/$name" == getChosenDisplayName()) {

--- a/app/src/main/java/org/sil/storyproducer/controller/translaterevise/TranslateReviseFrag.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/translaterevise/TranslateReviseFrag.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import org.sil.storyproducer.R
 import org.sil.storyproducer.controller.MultiRecordFrag
 
@@ -19,10 +18,11 @@ class TranslateReviseFrag : MultiRecordFrag() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return super.onCreateView(inflater, container, savedInstanceState)?.apply {
-            findViewById<TextView>(R.id.fragment_reference_text).text = viewModel.scriptureReference
-            findViewById<TextView>(R.id.fragment_scripture_text).text = viewModel.scriptureText
-        }
+        super.onCreateView(inflater, container, savedInstanceState)
+        setScriptureText(rootView!!.findViewById(R.id.fragment_scripture_text))
+        setReferenceText(rootView!!.findViewById(R.id.fragment_reference_text))
+
+        return rootView
     }
 
 }

--- a/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksActivity.kt
@@ -1,0 +1,256 @@
+package org.sil.storyproducer.controller.wordlink
+
+import android.app.AlertDialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.WindowManager
+import android.webkit.WebView
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetBehavior.*
+import org.sil.storyproducer.R
+import org.sil.storyproducer.tools.dpToPx
+import org.sil.storyproducer.controller.adapter.RecordingsListAdapter
+import org.sil.storyproducer.model.*
+import org.sil.storyproducer.tools.file.toJson
+import org.sil.storyproducer.tools.toolbar.PlayBackRecordingToolbar
+import java.util.*
+
+/**
+ * This activity shows information about the active Word Link so the user can learn more
+ * about the word as well as record an audio translation
+ */
+class WordLinksActivity : AppCompatActivity(), PlayBackRecordingToolbar.ToolbarMediaListener {
+
+    private lateinit var recordingToolbar : WordLinksRecordingToolbar
+    private lateinit var displayList : RecordingsListAdapter.RecordingsListModal
+    lateinit var bottomSheet: ConstraintLayout
+    private val wordLinkHistory: Stack<String> = Stack()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_wordlink)
+
+        Workspace.activePhase = Phase(PhaseType.WORD_LINKS)
+        val clickedTerm = intent.getStringExtra(WORD_LINKS_CLICKED_TERM)
+        Workspace.activeWordLink = Workspace.termToWordLinkMap[Workspace.termFormToTermMap[clickedTerm.toLowerCase()]]!!
+        wordLinkHistory.push(clickedTerm)
+
+        setupStatusBar()
+        setupToolbar(applicationContext)
+        setupBottomSheet()
+        setupNoteView()
+        setupRecordingList()
+
+        // Keeps keyboard from automatically popping up on opening activity
+        this.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
+    }
+
+    private fun setupStatusBar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            val hsv : FloatArray = floatArrayOf(0.0f,0.0f,0.0f)
+            Color.colorToHSV(ContextCompat.getColor(this, Workspace.activePhase.getColor()), hsv)
+            hsv[2] *= 0.8f
+            window.statusBarColor = Color.HSVToColor(hsv)
+        }
+    }
+
+    private fun setupToolbar(context: Context) {
+        val toolbar: androidx.appcompat.widget.Toolbar? = findViewById(R.id.wordlink_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setBackgroundDrawable(ColorDrawable(ContextCompat.getColor(context,
+                Workspace.activePhase.getColor())))
+    }
+
+    private fun setupBottomSheet() {
+        bottomSheet = findViewById(R.id.bottom_sheet)
+
+        from(bottomSheet).isFitToContents = false
+        from(bottomSheet).peekHeight = dpToPx(48, this)
+
+        if(Workspace.activeWordLink.wordLinkRecordings.isNotEmpty()){
+            from(bottomSheet).state = STATE_EXPANDED
+        }
+        else {
+            from(bottomSheet).state = STATE_COLLAPSED
+        }
+    }
+
+    private fun setupRecordingList() {
+        displayList = RecordingsListAdapter.RecordingsListModal(this, recordingToolbar)
+        displayList.embedList(findViewById(android.R.id.content))
+        displayList.setParentFragment(null)
+        displayList.show()
+    }
+
+    /**
+     * Updates the textViews with the current wordlink information
+     */
+    private fun setupNoteView() {
+        val actionBar = supportActionBar
+
+        actionBar?.title = wordLinkHistory.peek().toUpperCase();
+
+        val wordLinkTitleView = findViewById<TextView>(R.id.wordlink_title)
+        var titleText = ""
+        if(Workspace.activeWordLink.term.toLowerCase() != wordLinkHistory.peek().toLowerCase()) {
+            titleText = Workspace.activeWordLink.term
+        }
+        // format
+        for (termForm in Workspace.activeWordLink.termForms){
+            if(termForm != wordLinkHistory.peek()) {
+                if (titleText.isNotEmpty()) {
+                    titleText += " / $termForm"
+                }
+                else{
+                    titleText = termForm
+                }
+            }
+        }
+        if(titleText == ""){
+            wordLinkTitleView.visibility = View.GONE
+        }
+        else {
+            wordLinkTitleView.visibility = View.VISIBLE
+            wordLinkTitleView.text = titleText
+        }
+
+        val explanationView = findViewById<TextView>(R.id.explanation_text)
+        explanationView.text = Workspace.activeWordLink.explanation
+
+        val relatedTermsView = findViewById<TextView>(R.id.related_terms_text)
+        if (Workspace.activeWordLink.relatedTerms.isEmpty()) {
+            relatedTermsView.setText(R.string.wordlink_none);
+        } else {
+            relatedTermsView.text = Workspace.activeWordLink.relatedTerms.fold(SpannableStringBuilder()) {
+                result, relatedTerm -> result.append(stringToWordLink(relatedTerm, this)).append("   ")
+            }
+            relatedTermsView.movementMethod = LinkMovementMethod.getInstance()
+        }
+
+        val alternateRenderingsView = findViewById<TextView>(R.id.alternate_renderings_text)
+        alternateRenderingsView.text = Workspace.activeWordLink.alternateRenderings.fold(""){
+            result, alternateRendering -> "$result\u2022 $alternateRendering\n"
+        }.removeSuffix("\n")
+
+        // set up the toolbar
+        val bundle = Bundle()
+        bundle.putInt(WORD_LINKS_SLIDE_NUM, 0)
+        recordingToolbar = WordLinksRecordingToolbar()
+        recordingToolbar.arguments = bundle
+        supportFragmentManager.beginTransaction().replace(R.id.toolbar_for_recording_toolbar, recordingToolbar).commit()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_wordlink_view, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.closeWordLink -> {
+                saveWordLink()
+                if(intent.hasExtra(PHASE)) {
+                    Workspace.activePhase = Phase(intent.getSerializableExtra(PHASE) as PhaseType)
+                }
+                finish()
+                true
+            }
+            R.id.helpButton -> {
+                val alert = AlertDialog.Builder(this)
+                alert.setTitle("${Workspace.activePhase.getDisplayName()} Help")
+
+                val wv = WebView(this)
+                val iStream = assets.open(Phase.getHelpDocFile(Workspace.activePhase.phaseType))
+                val text = iStream.reader().use {
+                    it.readText()
+                }
+                wv.loadDataWithBaseURL(null,text,"text/html",null,null)
+                alert.setView(wv)
+                alert.setNegativeButton("Close") { dialog, _ ->
+                    dialog!!.dismiss()
+                }
+                alert.show()
+                true
+            }
+            else -> {
+                onBackPressed()
+                true
+            }
+        }
+    }
+
+    override fun onStoppedToolbarRecording() {
+        val recordingExpandableListView = findViewById<RecyclerView>(R.id.recordings_list)
+        recordingExpandableListView.adapter?.notifyDataSetChanged()
+        if(from(bottomSheet).state == STATE_COLLAPSED) {
+            from(bottomSheet).state = STATE_EXPANDED
+        }
+        recordingExpandableListView.smoothScrollToPosition(0)
+    }
+
+    override fun onStartedToolbarMedia() {
+        displayList.stopAudio()
+    }
+
+    override fun onStartedToolbarRecording() {
+        super.onStartedToolbarRecording()
+        displayList.resetRecordingList()
+    }
+
+    /**
+     * When the back button is pressed, the bottom sheet will close if currently opened or return to
+     * the previous word link or close the activity if there is no previous word link to return to
+     */
+    override fun onBackPressed() {
+        if( from(bottomSheet).state == STATE_EXPANDED){
+            from(bottomSheet).state = STATE_COLLAPSED
+        }
+        else {
+            saveWordLink()
+            wordLinkHistory.pop()
+            if (wordLinkHistory.isEmpty()) {
+                if(intent.hasExtra(PHASE)) {
+                    Workspace.activePhase = Phase(intent.getSerializableExtra(PHASE) as PhaseType)
+                }
+                super.onBackPressed()
+                finish()
+            } else {
+                Workspace.activeWordLink = Workspace.termToWordLinkMap[Workspace.termFormToTermMap[wordLinkHistory.peek().toLowerCase()]]!!
+                setupNoteView()
+                setupRecordingList()
+            }
+        }
+    }
+
+    fun replaceActivityWordLink(term: String) {
+        saveWordLink()
+        // Set word link from link as active word link
+        Workspace.activeWordLink = Workspace.termToWordLinkMap[Workspace.termFormToTermMap[term.toLowerCase()]]!!
+        // Add new word link fragments to stack
+        wordLinkHistory.push(term)
+        setupNoteView()
+        setupRecordingList()
+        from(bottomSheet).state = STATE_COLLAPSED
+    }
+
+    /**
+     * Saves the active word link to the workspace and exports an up-to-date json file for all word links
+     **/
+    private fun saveWordLink() {
+        Workspace.termToWordLinkMap[Workspace.activeWordLink.term] = Workspace.activeWordLink
+        val wordLinkList = WordLinkList(Workspace.termToWordLinkMap.values.toList())
+        Thread(Runnable{ let { wordLinkList.toJson(it) } }).start()
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksListActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksListActivity.kt
@@ -1,0 +1,167 @@
+
+package org.sil.storyproducer.controller.wordlink
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SearchView
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.*
+import android.widget.TextView
+import androidx.appcompat.app.ActionBar
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.navigation.NavigationView
+import org.sil.storyproducer.R
+import org.sil.storyproducer.controller.MainActivity
+import org.sil.storyproducer.controller.RegistrationActivity
+import org.sil.storyproducer.model.WORD_LINKS_CLICKED_TERM
+import org.sil.storyproducer.model.PHASE
+import org.sil.storyproducer.model.Workspace
+import org.sil.storyproducer.model.Workspace.termToWordLinkMap
+
+/**
+ * This activity shows all Word Links, clickable to go to the WordLinksActivity
+ */
+class WordLinksListActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
+
+    private lateinit var recyclerView: RecyclerView
+    private var mDrawerLayout: DrawerLayout? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_wordlink_list)
+
+        val wordLinkList = termToWordLinkMap.keys.toTypedArray()
+        wordLinkList.sortWith(String.CASE_INSENSITIVE_ORDER)
+
+        val viewManager = LinearLayoutManager(this)
+        val viewAdapter = WordLinkListAdapter(wordLinkList, this)
+
+        recyclerView = findViewById<RecyclerView>(R.id.wordlink_list).apply {
+            setHasFixedSize(true)
+            layoutManager = viewManager
+            adapter = viewAdapter
+        }
+
+        setupDrawer()
+
+        supportActionBar?.setTitle(R.string.title_activity_wordlink_list)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_wordlink_list_view, menu)
+        val searchItem = menu.findItem(R.id.search_button)
+        (searchItem.actionView as SearchView).setOnQueryTextListener(this)
+
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                mDrawerLayout!!.openDrawer(GravityCompat.START)
+                true
+            }
+            R.id.helpButton -> {
+                val alert = AlertDialog.Builder(this)
+                        .setTitle(getString(R.string.help))
+                        .setMessage(R.string.wordlink_list_help)
+                        .create()
+                alert.show()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+    override fun onQueryTextSubmit(p0: String?): Boolean {
+        return false
+    }
+
+    override fun onQueryTextChange(p0: String?): Boolean {
+        val newList = ArrayList<String>()
+        for (wl in termToWordLinkMap.keys) {
+            if (wl.toLowerCase().contains(p0?.toLowerCase() ?: "")) {
+                newList.add(wl)
+            }
+        }
+        newList.sortWith(String.CASE_INSENSITIVE_ORDER)
+        recyclerView.swapAdapter(WordLinkListAdapter(newList.toTypedArray(), this), true)
+        recyclerView.scrollToPosition(0)
+        return true
+    }
+
+    /**
+     * initializes the items that the drawer needs
+     */
+    private fun setupDrawer() {
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        val actionbar: ActionBar? = supportActionBar
+        actionbar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            setHomeAsUpIndicator(R.drawable.ic_menu_white_24dp)
+        }
+
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        supportActionBar!!.setHomeButtonEnabled(true)
+
+        mDrawerLayout = findViewById(R.id.drawer_layout)
+        //Lock from opening with left swipe
+        mDrawerLayout!!.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
+        val navigationView: NavigationView = findViewById(R.id.nav_view)
+        navigationView.setNavigationItemSelectedListener { menuItem ->
+            // set item as selected to persist highlight
+            menuItem.isChecked = true
+            // close drawer when item is tapped
+            mDrawerLayout!!.closeDrawers()
+
+            // Add code here to update the UI based on the item selected
+            // For example, swap UI fragments here
+            val intent: Intent
+            when (menuItem.itemId) {
+                R.id.nav_stories -> {
+                    intent = Intent(this, MainActivity::class.java)
+                    this.startActivity(intent)
+                    this.finish()
+                }
+                R.id.nav_word_link_list -> {
+                    // Current fragment
+                }
+                R.id.nav_registration -> {
+                    intent = Intent(this, RegistrationActivity::class.java)
+                    this.startActivity(intent)
+                    this.finish()
+                }
+            }
+            true
+        }
+    }
+}
+
+class WordLinkListAdapter(private val wordLinkTerms: Array<String>, private val context: Context) : RecyclerView.Adapter<WordLinkListAdapter.WordLinkListViewHolder>() {
+
+    class WordLinkListViewHolder(val item: View) : RecyclerView.ViewHolder(item)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): WordLinkListAdapter.WordLinkListViewHolder {
+        val rootView = LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false)
+        return WordLinkListViewHolder(rootView)
+    }
+
+    override fun onBindViewHolder(wordLinkListViewHolder: WordLinkListViewHolder, position: Int) {
+        val term = wordLinkTerms[position]
+        wordLinkListViewHolder.item.findViewById<TextView>(android.R.id.text1).text = term
+        wordLinkListViewHolder.item.setOnClickListener {
+            val intent = Intent(context , WordLinksActivity::class.java)
+            intent.putExtra(PHASE, Workspace.activePhase.phaseType)
+            intent.putExtra(WORD_LINKS_CLICKED_TERM, term)
+            context.startActivity(intent)
+        }
+    }
+
+    override fun getItemCount() = wordLinkTerms.size
+}

--- a/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksRecordingToolbar.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksRecordingToolbar.kt
@@ -1,0 +1,82 @@
+package org.sil.storyproducer.controller.wordlink
+
+import android.os.Bundle
+import com.google.android.material.bottomsheet.BottomSheetBehavior.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Workspace
+import org.sil.storyproducer.tools.hideKeyboard
+import org.sil.storyproducer.tools.toolbar.MultiRecordRecordingToolbar
+
+/**
+ * A class responsible for word link specific functionality for audio recording and playback.
+ *
+ * This class extends the recording, playback, and multi-recording listing functionality of its base
+ * classes. The class overrides the multi-record playlist button to display a bottom sheet that
+ * lists audio recordings instead of a modal that lists the audio recordings.
+ */
+class WordLinksRecordingToolbar : MultiRecordRecordingToolbar() {
+    lateinit var bottomSheet: ConstraintLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        bottomSheet = (activity as WordLinksActivity).bottomSheet
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val rootView = super.onCreateView(inflater, container, savedInstanceState)
+
+        from(bottomSheet).addBottomSheetCallback(bottomSheetCallback())
+        setWordLinksMultiRecordIcon(from(bottomSheet).state)
+
+        return rootView
+    }
+
+    private fun bottomSheetCallback(): BottomSheetCallback {
+        return object : BottomSheetCallback(){
+            override fun onStateChanged(view: View, newState: Int) {
+                setWordLinksMultiRecordIcon(newState)
+
+                if(newState == STATE_COLLAPSED){
+                    view.let { activity?.hideKeyboard(it) }
+                }
+                // Disables opening recording list when no recordings are available
+                if(Workspace.activeWordLink.wordLinkRecordings.isEmpty()){
+                    from(bottomSheet).state = STATE_COLLAPSED
+                }
+            }
+
+            override fun onSlide(view: View, newState: Float) {}
+        }
+    }
+
+    /**
+     * The state of the bottom sheet will determine the icon used.
+     */
+    private fun setWordLinksMultiRecordIcon(state: Int){
+        if(state == STATE_EXPANDED){
+            multiRecordButton.setBackgroundResource(R.drawable.ic_keyboard_arrow_up_white_48dp)
+        }
+        else if(state == STATE_COLLAPSED){
+            multiRecordButton.setBackgroundResource(R.drawable.ic_playlist_play_white_48dp)
+        }
+    }
+
+    override fun multiRecordButtonOnClickListener(): View.OnClickListener {
+        return View.OnClickListener {
+            stopToolbarMedia()
+
+            toolbarMediaListener.onStartedToolbarMedia()
+
+            if (from(bottomSheet).state == STATE_EXPANDED) {
+                from(bottomSheet).state = STATE_COLLAPSED
+            } else {
+                from(bottomSheet).state = STATE_EXPANDED
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/model/Phase.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Phase.kt
@@ -9,6 +9,7 @@ import org.sil.storyproducer.controller.export.ShareActivity
 import org.sil.storyproducer.controller.learn.LearnActivity
 import org.sil.storyproducer.controller.pager.PagerBaseActivity
 import org.sil.storyproducer.controller.remote.WholeStoryBackTranslationActivity
+import org.sil.storyproducer.controller.wordlink.WordLinksActivity
 
 /**
  * PhaseType enum used to track current phase
@@ -22,6 +23,7 @@ enum class PhaseType {
     @Json(name="STORY_LIST") STORY_LIST,
     @Json(name="LEARN") LEARN,
     @Json(name="DRAFT") TRANSLATE_REVISE,
+    @Json(name="WORD_LINKS") WORD_LINKS,
     @Json(name="COMMUNITY_CHECK") COMMUNITY_WORK,
     @Json(name="WHOLE_STORY") WHOLE_STORY,
     @Json(name="BACKT") BACK_T,
@@ -63,9 +65,10 @@ class Phase (val phaseType: PhaseType) {
      */
     fun getColor() : Int {
         return when(phaseType){
-            PhaseType.LEARN -> R.color.learn_phase
+            PhaseType.LEARN            -> R.color.learn_phase
             PhaseType.TRANSLATE_REVISE -> R.color.translate_revise_phase
-            PhaseType.COMMUNITY_WORK   -> R.color.comunity_work_phase
+            PhaseType.WORD_LINKS       -> R.color.word_links_phase
+            PhaseType.COMMUNITY_WORK   -> R.color.community_work_phase
             PhaseType.WHOLE_STORY      -> R.color.whole_story_phase
             PhaseType.BACK_T           -> R.color.backT_phase
             PhaseType.REMOTE_CHECK     -> R.color.remote_check_phase
@@ -104,6 +107,7 @@ class Phase (val phaseType: PhaseType) {
         return when (phaseType) {
             PhaseType.LEARN            -> "Learn"
             PhaseType.TRANSLATE_REVISE -> "Translate + Revise"
+            PhaseType.WORD_LINKS       -> "Word Links"
             PhaseType.COMMUNITY_WORK   -> "Community Work"
             PhaseType.WHOLE_STORY      -> "Whole Story"
             PhaseType.BACK_T           -> "Back Translation"
@@ -123,6 +127,7 @@ class Phase (val phaseType: PhaseType) {
     fun getDirectorySafeName() : String {
         return when (phaseType) {
             PhaseType.TRANSLATE_REVISE -> "Translation Draft"
+            PhaseType.WORD_LINKS       -> "WordLinks"
             PhaseType.COMMUNITY_WORK   -> "Comment"
             PhaseType.WHOLE_STORY      -> "Whole"
             PhaseType.BACK_T           -> "BackTrans"
@@ -141,6 +146,7 @@ class Phase (val phaseType: PhaseType) {
     fun getFileSafeName() : String {
         return when (phaseType) {
             PhaseType.TRANSLATE_REVISE -> "Translate"
+            PhaseType.WORD_LINKS       -> "WordLinks"
             PhaseType.COMMUNITY_WORK   -> "Community"
             PhaseType.WHOLE_STORY      -> "Whole"
             PhaseType.BACK_T           -> "BackTrans"
@@ -163,6 +169,7 @@ class Phase (val phaseType: PhaseType) {
             PhaseType.STORY_LIST       -> MainActivity::class.java
             PhaseType.LEARN            -> LearnActivity::class.java
             PhaseType.TRANSLATE_REVISE -> PagerBaseActivity::class.java
+            PhaseType.WORD_LINKS       -> WordLinksActivity::class.java
             PhaseType.COMMUNITY_WORK   -> PagerBaseActivity::class.java
             PhaseType.WHOLE_STORY      -> WholeStoryBackTranslationActivity::class.java
             PhaseType.BACK_T           -> PagerBaseActivity::class.java
@@ -181,6 +188,13 @@ class Phase (val phaseType: PhaseType) {
     fun getCombNames(slideNum:Int = Workspace.activeSlideNum) : MutableList<String>?{
         return when (phaseType){
             PhaseType.TRANSLATE_REVISE -> Workspace.activeStory.slides[slideNum].translateReviseAudioFiles
+            PhaseType.WORD_LINKS       -> {
+                val audioFiles : MutableList<String> = mutableListOf()
+                for(audioFile in Workspace.activeWordLink.wordLinkRecordings) {
+                    audioFiles.add(audioFile.audioRecordingFilename)
+                }
+                audioFiles
+            }
             PhaseType.COMMUNITY_WORK   -> Workspace.activeStory.slides[slideNum].communityWorkAudioFiles
             PhaseType.BACK_T           -> Workspace.activeStory.slides[slideNum].backTranslationAudioFiles
             PhaseType.VOICE_STUDIO     -> Workspace.activeStory.slides[slideNum].voiceStudioAudioFiles

--- a/app/src/main/java/org/sil/storyproducer/model/WordLink.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/WordLink.kt
@@ -1,0 +1,91 @@
+package org.sil.storyproducer.model
+
+import android.content.Intent
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.TextPaint
+import android.text.style.ClickableSpan
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.squareup.moshi.JsonClass
+import org.sil.storyproducer.R
+import org.sil.storyproducer.controller.wordlink.WordLinksActivity
+
+/**
+ * A list of all the word links (used for saving all word links in a single file)
+ **/
+@JsonClass(generateAdapter = true)
+class WordLinkList (val wordLinks: List<WordLink>) {
+    companion object
+}
+
+@JsonClass(generateAdapter = true)
+data class WordLinkRecording (
+    var audioRecordingFilename : String = "",
+    var textBackTranslation : String = "",
+    var isTextBackTranslationSubmitted: Boolean = false) {
+        companion object
+}
+
+@JsonClass(generateAdapter = true)
+data class WordLink (
+        var term: String = "",
+        var termForms: List<String> = listOf(),
+        var alternateRenderings: List<String> = listOf(),
+        var explanation: String = "",
+        var relatedTerms: List<String> = listOf(),
+        var wordLinkRecordings: MutableList<WordLinkRecording> = mutableListOf(),
+        var chosenWordLinkFile: String = "") {
+    companion object
+}
+
+/**
+ * Takes a string and returns a spannable string with links to open wordlink Activity
+ *
+ * @param string The string that contains wordlinks
+ * @param fragmentActivity The current activity
+ * @return A spannable string
+ **/
+fun stringToWordLink (string: String, fragmentActivity: FragmentActivity?) : SpannableString {
+    val spannableString = SpannableString(string)
+    if (Workspace.termFormToTermMap.containsKey(string.toLowerCase())) {
+        val clickableSpan = createWordLinkClickableSpan(string, fragmentActivity)
+        spannableString.setSpan(clickableSpan, 0, string.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+    return spannableString
+}
+
+/**
+ * Converts a string to a clickableSpan that will open the WordLinksActivity when clicked
+ *
+ * @param term the wordlink
+ * @param fragmentActivity the current activity
+ * @return The link to open the wordlink
+ **/
+private fun createWordLinkClickableSpan(term: String, fragmentActivity: FragmentActivity?): ClickableSpan {
+    return object : ClickableSpan() {
+        override fun onClick(textView: View) {
+            if (Workspace.activePhase.phaseType == PhaseType.WORD_LINKS && fragmentActivity is WordLinksActivity) {
+                fragmentActivity.replaceActivityWordLink(term)
+            }
+            else if (Workspace.activePhase.phaseType != PhaseType.WORD_LINKS) {
+                //Start a new word links activity and keep a reference to the parent phase
+                val intent = Intent(fragmentActivity, WordLinksActivity::class.java)
+                intent.putExtra(PHASE, Workspace.activePhase.phaseType)
+                intent.putExtra(WORD_LINKS_CLICKED_TERM, term)
+                fragmentActivity?.startActivity(intent)
+            }
+        }
+
+        override fun updateDrawState(drawState: TextPaint) {
+            val wordLink = Workspace.termToWordLinkMap[Workspace.termFormToTermMap[term.toLowerCase()]]
+            val hasRecording = wordLink?.wordLinkRecordings?.isNotEmpty()
+
+            if(hasRecording != null && hasRecording){
+                drawState.linkColor = ContextCompat.getColor(fragmentActivity!!.applicationContext, R.color.lightGray)
+            }
+            super.updateDrawState(drawState)
+        }
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/model/WordLinkSearchTree.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/WordLinkSearchTree.kt
@@ -1,0 +1,127 @@
+package org.sil.storyproducer.model
+
+/**
+ * The purpose of this class is to make searching for multi-word wordlinks possible and fast within a larger paragraph of text.
+ * The point of this class is to quickly differentiate between similar wordlinks (ones which begin with the same words).
+ * Example: feast, Feast of Pentecost, Feast of Shelters
+ *
+ * In this class a word refers to a consecutive string of letters, or any individual non-letter symbol.
+ *
+ * When building the WordLinkSearchTree (WordLink Search Tree) all starting words of wordlinks that are the same would get combined into a single node.
+ * The children of that node would be all the possible next words that could come after the starting word to make up a wordlinks.
+ * When searching we would traverse this tree word by word as long as we get words that match.
+ * This will get us the longest match - the longest possible wordlinks from a given list of words.
+ */
+class WordLinkSearchTree {
+    private val root: WordNode = WordNode()
+
+    /**
+     * This function takes in a single term and builds up the tree based on the words in that term.
+     * The tree would be as deep as the term with the most words.
+     * If a given word already exists in current node's map, navigate down that node, otherwise create a new node.
+     *
+     * @param word the word to insert into the tree
+     */
+    fun insertTerm(word: String) {
+        val words = splitBeforeAndAfterAnyNonLetters(word)
+        var currentNode = root
+
+        for (w in words) {
+            val nextNode = currentNode.childWords[w.toLowerCase()] ?: WordNode()
+            currentNode.childWords[w.toLowerCase()] = nextNode
+            currentNode = nextNode
+        }
+        currentNode.isWordLink = true
+    }
+
+    /**
+     * The purpose of this function is to split a paragraph of text into a list of wordlinks and non-wordlinks strings between those wordlinks.
+     *
+     * @param text the text containing wordlinks
+     * @return A list of Strings
+     */
+    fun splitOnWordLinks(text: String): List<String> {
+        val words = splitBeforeAndAfterAnyNonLetters(text)
+        val resultPhrases: MutableList<String> = mutableListOf()
+        var nonWordLinkPhrase = ""
+
+        while (words.size > 0) {
+            val wordLinkPhrase = getIfWordLink(words, root)
+            // If the returned wordlink is empty, no wordlink was found.
+            // All parsed words are reinserted onto the list of terms to parse.
+            // The first word is removed as this word is guaranteed to not be part of a wordlink.
+            // That first word is appended to the string of words since the last wordlink was found.
+            if(wordLinkPhrase == ""){
+                nonWordLinkPhrase += words.removeAt(0)
+            }
+            else{
+                resultPhrases.add(nonWordLinkPhrase)
+                resultPhrases.add(wordLinkPhrase)
+                nonWordLinkPhrase = ""
+            }
+        }
+        resultPhrases.add(nonWordLinkPhrase)
+        resultPhrases.removeAll{ it == "" }
+
+        return resultPhrases
+    }
+
+    /**
+     * The purpose of this function is to return the longest possible term made up of the next consecutive words left to parse.
+     * It returns an empty string if no wordlink can be found
+     * and any consumed words are reinserted into the main list of words that have yet to be parsed.
+     *
+     * This function is recursive. It will navigate down the tree as long as
+     * the next word to be parsed matches a word in the current node's map.
+     * When this occurs, the function will propagate back up until it finds a node that is the end of a wordlink
+     * and will then begin appending words to its return value.
+     *
+     * @param words
+     * @param currentNode
+     * @return A string
+     */
+    private fun getIfWordLink(words: MutableList<String>, currentNode: WordNode): String{
+        if(words.isNotEmpty()){
+            val word = words.removeAt(0)
+
+            if(currentNode.childWords.containsKey(word.toLowerCase())){
+                val nextNode = currentNode.childWords[word.toLowerCase()]!!
+                val wordLink = getIfWordLink(words, nextNode)
+
+                if(nextNode.isWordLink || wordLink != ""){
+                    return word + wordLink
+                }
+            }
+            words.add(0, word)
+        }
+        return ""
+    }
+
+    /**
+     * This function splits a given string so that all consecutive characters that are letters are split into their own strings.
+     * Every other individual character (",", ".", " ", etc.) are split into their own strings.
+     * This makes it possible to separate symbols from words.
+     * Example: Jesus's Spirit -> "Jesus", "'", "s", " ", "Spirit"
+     *
+     * @param text
+     * @return A list of strings
+     */
+    private fun splitBeforeAndAfterAnyNonLetters(text: String): MutableList<String>{
+        // This regex uses lookahead and lookbehind characters to check if any character has a non-letter before or after it
+        val words = text.split(Regex("(?![a-zA-Z])|(?<![a-zA-Z])")).toMutableList()
+        words.removeAll { it == "" }
+        return words
+    }
+
+
+    private class WordNode {
+        var isWordLink: Boolean = false
+        /*
+         * The key in the map and it's corresponding WordNode together represent a word.
+         * The word string isn't stored in the WordNode itself as it isn't needed in the algorithm.
+         * A map is used because it can be quickly searched by a key which would be the next words.
+         * A word could have any number of next words because multiple wordlinks could start with the same word.
+         */
+        var childWords: MutableMap<String, WordNode> = mutableMapOf()
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -1,27 +1,37 @@
 package org.sil.storyproducer.model
 
+import WordLinksCSVReader
 import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
+import android.os.ParcelFileDescriptor
 import android.provider.Settings.Secure
 import android.util.Log
+import android.widget.Toast
 import androidx.documentfile.provider.DocumentFile
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.sil.storyproducer.R
-import org.sil.storyproducer.tools.file.deleteWorkspaceFile
-import org.sil.storyproducer.tools.file.getChildOutputStream
-import org.sil.storyproducer.tools.file.workspaceRelPathExists
+import org.sil.storyproducer.tools.file.*
 import java.io.File
 import java.io.IOException
+import java.text.SimpleDateFormat
+import java.io.InputStreamReader
 import java.util.*
 
 
 internal const val SLIDE_NUM = "CurrentSlideNum"
 internal const val DEMO_FOLDER = "000 Unlocked demo story Storm"
+internal const val PHASE = "Phase"
 
-object Workspace{
+internal const val WORD_LINKS_DIR = "wordlinks"
+internal const val WORD_LINKS_CSV_FILE = "wordlinks.csv"
+internal const val WORD_LINKS_JSON_FILE = "wordlinks.json"
+internal const val WORD_LINKS_CLICKED_TERM = "ClickedTerm"
+internal const val WORD_LINKS_SLIDE_NUM = "CurrentSlideNum"
+
+object Workspace {
     var workdocfile = DocumentFile.fromFile(File(""))
         set(value) {
             field = value
@@ -40,12 +50,22 @@ object Workspace{
     // This is set in BaseController function onStoriesUpdated()
     var showRegistration = false
 
+    // word links
+    lateinit var activeWordLink: WordLink
+    var termToWordLinkMap: MutableMap<String, WordLink> = mutableMapOf()
+    var termFormToTermMap: MutableMap<String, String> = mutableMapOf()
+    var WLSTree = WordLinkSearchTree()
+
     var activeStory: Story = emptyStory()
     set(value){
         field = value
         //You are switching the active story.  Recall the last phase and slide.
         activePhase = Phase(value.lastPhaseType)
         activeSlideNum = value.lastSlideNum
+        // DKH - Updated 06/03/2021  for Issue 555: Report Story Parse Exceptions and Handle them appropriately
+        // Record time when the story was last run - this will show up in the story.json file
+        // This is mainly used for debugging a story.json file that has a parse error
+        value.storyToJasonTimeStamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(Date())
     }
     var activePhase: Phase = Phase(PhaseType.LEARN)
         set(value){
@@ -56,12 +76,30 @@ object Workspace{
             }
         }
     val activeDirRoot: String
-    get(){return activeStory.title }
+    get() {
+        return if (activePhase.phaseType == PhaseType.WORD_LINKS) {
+            WORD_LINKS_DIR
+        } else {
+            activeStory.title
+        }
+    }
 
-    val activeDir: String = PROJECT_DIR
+    val activeDir: String
+    get() {
+        return if (activePhase.phaseType == PhaseType.WORD_LINKS) {
+            activeWordLink.term
+        } else {
+            PROJECT_DIR
+        }
+    }
+
     val activeFilenameRoot: String
     get() {
-        return "${activePhase.getFileSafeName()}${ Workspace.activeSlideNum }"
+        return if(activePhase.phaseType == PhaseType.WORD_LINKS) {
+            activeWordLink.term
+        } else {
+            return "${activePhase.getFileSafeName()}${ activeSlideNum }"
+        }
     }
 
     var activeSlideNum: Int = -1
@@ -98,8 +136,80 @@ object Workspace{
             // Initiate new workspace path
             workdocfile = DocumentFile.fromTreeUri(context, uri)!!
             registration.load(context)
+
+            // load in the Word Links
+            importWordLinks(context)
         } catch (e: Exception) {
             Log.e("setupWorkspacePath", "Error setting up new workspace path!", e)
+        }
+    }
+
+    private fun importWordLinks(context: Context) {
+        val wordLinksDir = workdocfile.findFile(WORD_LINKS_DIR)
+        // check that word links directory exists
+        if (wordLinksDir != null) {
+            importWordLinksFromCSV(context, wordLinksDir)
+            importWordLinksFromJsonFiles(context, wordLinksDir)
+            mapTermFormsToTerms()
+            buildWLSTree()
+        }
+    }
+
+    private fun importWordLinksFromCSV(context: Context, wordLinksDir: DocumentFile){
+        val wordLinksFile = wordLinksDir.findFile(WORD_LINKS_CSV_FILE)
+        if (wordLinksFile != null) {
+            try {
+                // open a raw file descriptor to access data under the URI
+                context.contentResolver.openFileDescriptor(wordLinksFile.uri, "r").use { pfd ->
+                    ParcelFileDescriptor.AutoCloseInputStream(pfd).use { inputStream ->
+                        InputStreamReader(inputStream).use { streamReader ->
+                            WordLinksCSVReader(streamReader).use { wordLinkCSVReader ->
+                                val wordLinks = wordLinkCSVReader.readAll()
+                                wordLinks.forEach { wl ->
+                                    termToWordLinkMap[wl.term] = wl
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (exception: Exception) {
+                Toast.makeText(context, R.string.wordlinks_csv_read_error, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun importWordLinksFromJsonFiles(context: Context, wordLinksDir: DocumentFile){
+        if(wordLinksDir.findFile(WORD_LINKS_JSON_FILE) != null) {
+            try {
+                wordLinkListFromJson(context)?.wordLinks?.forEach { wl ->
+                    if (termToWordLinkMap.containsKey(wl.term)) {
+                        termToWordLinkMap[wl.term]?.wordLinkRecordings = wl.wordLinkRecordings
+                        termToWordLinkMap[wl.term]?.chosenWordLinkFile = wl.chosenWordLinkFile
+                    } else {
+                        termToWordLinkMap[wl.term] = wl
+                    }
+                }
+            }
+            catch(exception: Exception) {
+                Toast.makeText(context, R.string.wordlinks_json_read_error, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun mapTermFormsToTerms() {
+        for (wl in termToWordLinkMap.values) {
+            val term = wl.term
+            termFormToTermMap[term.toLowerCase()] = term
+            for (termForm in wl.termForms) {
+                termFormToTermMap[termForm.toLowerCase()] = term
+            }
+        }
+    }
+
+    private fun buildWLSTree() {
+        for (termForm in termFormToTermMap.keys) {
+            WLSTree.insertTerm(termForm)
         }
     }
 
@@ -196,7 +306,7 @@ object Workspace{
     }
 
     fun goToNextPhase() : Boolean {
-        if(activePhaseIndex == -1) return false //phases not initizialized
+        if(activePhaseIndex == -1) return false //phases not initialized
         if(activePhaseIndex >= phases.size - 1) {
             activePhaseIndex = phases.size - 1
             return false
@@ -208,7 +318,7 @@ object Workspace{
     }
 
     fun goToPreviousPhase() : Boolean {
-        if(activePhaseIndex == -1) return false //phases not initizialized
+        if(activePhaseIndex == -1) return false //phases not initialized
         if(activePhaseIndex <= 0) {
             activePhaseIndex = 0
             return false

--- a/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
@@ -24,6 +24,9 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 activity.finish()
             }
             1 -> {
+                activity.showWordLinksList()
+            }
+            2 -> {
                 // 06/14/2021 - DKH, Issue 407, Pull Request 561 - Merge into Latest sillsdev
                 // The new Filter layout for the Story Templates broke the capability to launch
                 // the showRegistration () from the calling activity.  SP uses the paradigm of
@@ -42,13 +45,13 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 Workspace.showRegistration = true
                 activity.showMain()
             }
-            2 -> {
+            3 -> {
                 activity.showSelectTemplatesFolderDialog()
             }
-            3 -> {
+            4 -> {
                 Workspace.addDemoToWorkspace(activity)
             }
-            4 -> {
+            5 -> {
                 activity.showAboutDialog()
             }
         }

--- a/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/FileIO.kt
@@ -3,13 +3,12 @@ package org.sil.storyproducer.tools.file
 
 import android.content.Context
 import android.database.Cursor
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import org.sil.storyproducer.R
+import org.sil.storyproducer.model.WORD_LINKS_DIR
 import org.sil.storyproducer.model.Story
 import org.sil.storyproducer.model.Workspace
 import java.io.File
@@ -110,6 +109,10 @@ fun getStoryChildOutputStream(context: Context, relPath: String, mimeType: Strin
     // writing a smaller file.  Garbage data caused story.json file corruption.
     // FIX - Added the ability to pass mode to getChildOutputStream.  Pass mode of write/truncate ("wt")
     return getChildOutputStream(context, "$dirRoot/$relPath", mimeType,"wt")
+}
+
+fun getWordLinksChildOutputStream(context: Context, relPath: String, mimeType: String = "") : OutputStream? {
+    return getChildOutputStream(context, "$WORD_LINKS_DIR/$relPath", mimeType, "wt")
 }
 
 fun storyRelPathExists(context: Context, relPath: String, dirRoot: String = Workspace.activeDirRoot) : Boolean{

--- a/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksCSVReader.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksCSVReader.kt
@@ -38,8 +38,12 @@ class WordLinksCSVReader(reader: Reader): AutoCloseable {
 
         wordLink.term = line[1].trim()
         wordLink.termForms = stringToList(line[2], ",")
-        wordLink.alternateRenderings = stringToList(line[3], ";")
-        wordLink.explanation = line[4].trim()
+        // DKH - 08/27/2021
+        // Do not process column D "Other language examples (back translations)" in WordLinks spreadsheet
+        // wordLink.alternateRenderings = stringToList(line[3], ";") // column D
+        // DKH - 08/27/2021
+        // Do not process column E "Meaning notes/Definitions" in WordLinks spreadsheet
+        // wordLink.explanation = line[4].trim()   // column E
         wordLink.relatedTerms = stringToList(line[5], ",")
 
         return wordLink

--- a/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksCSVReader.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksCSVReader.kt
@@ -1,0 +1,63 @@
+import com.opencsv.CSVReader
+import org.sil.storyproducer.model.WordLink
+import java.io.Reader
+
+/**
+ * The purpose of this class is to parse wordlink data from a csv file and load into a list of WordLink objects
+ *
+ * @since 3.1
+ * @authors Aaron Cannon, Jake Allinson
+ */
+class WordLinksCSVReader(reader: Reader): AutoCloseable {
+    private val csvReader = CSVReader(reader)
+
+    init {
+        val numberOfHeaderRows = 1
+        csvReader.skip(numberOfHeaderRows)
+    }
+
+    fun readAll(): List<WordLink>{
+        val wordLinks: MutableList<WordLink> = mutableListOf()
+
+        val lines = csvReader.readAll()
+        for (line in lines) {
+            val wordLink = lineToWordLink(line)
+            wordLinks.add(wordLink)
+        }
+        wordLinks.removeAll{ wordlink -> wordlink.term == ""}
+
+        return wordLinks
+    }
+
+    override fun close() {
+        csvReader.close()
+    }
+
+    private fun lineToWordLink(line: Array<String>): WordLink {
+        val wordLink = WordLink()
+
+        wordLink.term = line[1].trim()
+        wordLink.termForms = stringToList(line[2], ",")
+        wordLink.alternateRenderings = stringToList(line[3], ";")
+        wordLink.explanation = line[4].trim()
+        wordLink.relatedTerms = stringToList(line[5], ",")
+
+        return wordLink
+    }
+
+    /*
+     * The purpose of this method is to split a string based on a give separator.
+     */
+    private fun stringToList(field: String, separator: String): List<String>{
+        if(field.isNotEmpty()) {
+            val list = field.split(separator)
+            val trimmedList = list.asSequence().map { it.trim() }.toMutableList()
+            //Trim any empty string elements
+            trimmedList.removeAll { it == "" }
+            return trimmedList
+        }
+        else{
+            return listOf()
+        }
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksIO.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/WordLinksIO.kt
@@ -1,0 +1,33 @@
+package org.sil.storyproducer.tools.file
+
+import android.content.Context
+import com.squareup.moshi.Moshi
+import org.sil.storyproducer.model.*
+import org.sil.storyproducer.model.WORD_LINKS_DIR
+import org.sil.storyproducer.model.WORD_LINKS_JSON_FILE
+
+fun WordLinkList.toJson(context: Context){
+    val moshi = Moshi
+            .Builder()
+            .build()
+    val adapter = WordLinkList.jsonAdapter(moshi)
+    val oStream = getWordLinksChildOutputStream(context,
+            WORD_LINKS_JSON_FILE,"")
+    if(oStream != null) {
+        oStream.write(adapter.toJson(this).toByteArray(Charsets.UTF_8))
+        oStream.close()
+    }
+}
+
+/**
+ * Retrieves the list of all the word links from wordlinks.json
+ */
+fun wordLinkListFromJson(context: Context): WordLinkList? {
+    val moshi = Moshi
+            .Builder()
+            .add(UriAdapter())
+            .build()
+    val adapter = WordLinkList.jsonAdapter(moshi)
+    val fileContents = getStoryText(context, WORD_LINKS_JSON_FILE, WORD_LINKS_DIR) ?: return null
+    return adapter.fromJson(fileContents)
+}

--- a/app/src/main/java/org/sil/storyproducer/tools/media/AudioPlayer.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/media/AudioPlayer.kt
@@ -3,9 +3,10 @@ package org.sil.storyproducer.tools.media
 import android.content.Context
 import android.media.MediaPlayer
 import android.net.Uri
+import org.sil.storyproducer.model.PhaseType
 import org.sil.storyproducer.model.Workspace
 import org.sil.storyproducer.tools.file.getStoryUri
-import java.io.IOException
+import org.sil.storyproducer.model.WORD_LINKS_DIR
 
 class AudioPlayer {
 
@@ -79,7 +80,12 @@ class AudioPlayer {
 
     fun setStorySource(context: Context, relPath: String,
                        storyName: String = Workspace.activeStory.title) : Boolean {
-        val uri: Uri = getStoryUri(relPath,storyName) ?: return false
+        val uri: Uri = if (Workspace.activePhase.phaseType == PhaseType.WORD_LINKS){
+            getStoryUri(relPath, WORD_LINKS_DIR) ?: return false
+        }
+        else{
+            getStoryUri(relPath,storyName) ?: return false
+        }
         return setSource(context, uri)
     }
 

--- a/app/src/main/res/drawable/ic_keyboard_arrow_down_white_48dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_down_white_48dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard_arrow_up_white_48dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_up_white_48dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_search_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/layout/activity_log_view.xml
+++ b/app/src/main/res/layout/activity_log_view.xml
@@ -77,7 +77,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="0.85"
-                android:background="@color/comunity_work_phase"
+                android:background="@color/community_work_phase"
                 android:paddingStart="5dp"
                 android:paddingEnd="5dp"
                 >

--- a/app/src/main/res/layout/activity_wordlink.xml
+++ b/app/src/main/res/layout/activity_wordlink.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".controller.wordlink.WordLinksActivity"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/wordlink_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme"
+        app:layout_anchorGravity="top"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/wordlink_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/gray"
+        android:orientation="vertical">
+
+        <ScrollView
+            android:id="@+id/linearLayout3"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_anchorGravity="bottom"
+            android:layout_marginBottom="50dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/wordlink_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/word_links_phase_secondary"
+                    android:elevation="2dp"
+                    android:paddingLeft="8dp"
+                    android:paddingTop="4dp"
+                    android:paddingRight="8dp"
+                    android:paddingBottom="4dp"
+                    android:textSize="@dimen/text_title" />
+
+                <TextView
+                    android:id="@+id/meaning_notes_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    android:text="@string/wordlink_notes"
+                    android:textSize="@dimen/large_text"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/explanation_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    android:textSize="@dimen/text_body" />
+
+                <LinearLayout
+                    android:id="@+id/related_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginBottom="4dp"
+                    android:background="@color/lightDarkGrey"
+                    android:orientation="vertical"
+                    android:padding="8dp">
+
+                    <TextView
+                        android:id="@+id/related_terms_label"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/wordlink_related_terms"
+                        android:textSize="@dimen/large_text"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/related_terms_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textSize="@dimen/text_body" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/other_languages_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    android:text="@string/wordlink_other_langauge_examples"
+                    android:textSize="@dimen/large_text"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/alternate_renderings_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    android:textSize="@dimen/text_body" />
+            </LinearLayout>
+        </ScrollView>
+
+        <include layout="@layout/fragment_wordlink_recording_list" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_wordlink_list.xml
+++ b/app/src/main/res/layout/activity_wordlink_list.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorPrimary"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="?attr/actionBarTheme" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/wordlink_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@color/darkGray"
+        android:fitsSystemWindows="true"
+        app:menu="@menu/drawer_view"/>
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/exported_video_row.xml
+++ b/app/src/main/res/layout/exported_video_row.xml
@@ -1,46 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="40dp">
+
     <ImageButton
         android:id="@+id/video_play_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:src="@drawable/ic_play_arrow_white_48dp"
+        android:layout_margin="8dp"
         android:backgroundTint="@color/transparent"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
-        android:contentDescription="@string/play" />
+        android:contentDescription="@string/play"
+        android:src="@drawable/ic_play_arrow_white_48dp" />
 
     <ImageButton
         android:id="@+id/file_share_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:src="@drawable/ic_share_white_24dp"
+        android:layout_margin="8dp"
         android:backgroundTint="@color/transparent"
-        android:layout_toEndOf="@+id/video_play_button"
-        android:layout_centerVertical="true"
-        android:layout_margin="12dp"
-        android:contentDescription="@string/share" />
+        android:contentDescription="@string/share"
+        android:src="@drawable/ic_share_white_24dp" />
 
     <TextView
         android:id="@+id/video_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="@dimen/large_text"
-        android:layout_toEndOf="@+id/file_share_button"
-        android:layout_toStartOf="@+id/file_delete_button"
-        android:layout_centerVertical="true"
-        android:layout_margin="6dp" />
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:gravity="center|start"
+        android:textSize="@dimen/large_text" />
 
     <ImageButton
         android:id="@+id/file_delete_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:src="@drawable/ic_delete_forever_white_36dp"
+        android:layout_margin="8dp"
         android:backgroundTint="@color/transparent"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
-        android:contentDescription="@string/share" />
+        android:contentDescription="@string/share"
+        android:src="@drawable/ic_delete_forever_white_36dp" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wordlink_recording_list.xml
+++ b/app/src/main/res/layout/fragment_wordlink_recording_list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/bottom_sheet"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/gray"
+    app:behavior_peekHeight="48dp"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+    <FrameLayout
+        android:id="@+id/toolbar_for_recording_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/recordings_list"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recordings_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="@dimen/wordlink_layout_margin"
+        android:layout_marginEnd="@dimen/wordlink_layout_margin"
+        android:layout_marginBottom="@dimen/wordlink_layout_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar_for_recording_toolbar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -5,6 +5,9 @@
             android:id="@+id/nav_stories"
             android:title="@string/title_activity_story_templates" />
         <item
+            android:id="@+id/nav_word_link_list"
+            android:title="@string/title_activity_wordlink_list" />
+        <item
             android:id="@+id/nav_registration"
             android:title="@string/update_registration" />
         <item

--- a/app/src/main/res/menu/menu_wordlink_list_view.xml
+++ b/app/src/main/res/menu/menu_wordlink_list_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/search_button"
+        android:icon="@drawable/ic_search_white_24dp"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom|collapseActionView" />
+    <item
+        android:id="@+id/helpButton"
+        android:icon="@drawable/ic_help_white_24dp"
+        android:title="@string/help"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/menu/menu_wordlink_view.xml
+++ b/app/src/main/res/menu/menu_wordlink_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/closeWordLink"
+        android:icon="@drawable/ic_close_white_36dp"
+        android:title="@string/wordlink_close"
+        app:showAsAction="always"/>
+    <item
+        android:id="@+id/helpButton"
+        android:icon="@drawable/ic_help_white_24dp"
+        android:title="@string/help"
+        app:showAsAction="ifRoom"/>
+</menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,9 @@
     <color name="transparent">#00000000</color>
     <color name="learn_phase">#2AA198</color>
     <color name="translate_revise_phase">#DC322F</color>
-    <color name="comunity_work_phase">#859900</color>
+    <color name="word_links_phase">#91602F</color>
+    <color name="word_links_phase_secondary">#7E5329</color>
+    <color name="community_work_phase">#859900</color>
     <color name="accuracy_check_phase">#268DB2</color>
     <color name="voice_studio_phase">#D33682</color>
     <color name="finalize_phase">#6C71C4</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,5 +16,7 @@
     <dimen name="reference_audio_button">50dp</dimen>
     <dimen name="alternate_rendering_indent">16dp</dimen>
     <dimen name="text_margin">16dp</dimen>
+    <dimen name="wordlink_layout_margin">8dp</dimen>
+    <dimen name="wordlink_text_margin">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/global_menu_array.xml
+++ b/app/src/main/res/values/global_menu_array.xml
@@ -2,6 +2,7 @@
 <resources>
     <string-array name="global_menu_array">
         <item>@string/title_activity_story_templates</item>
+        <item>@string/title_activity_wordlink_list</item>
         <item>@string/update_registration</item>
         <item>@string/update_workspace</item>
         <item>@string/copy_demo</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="whole_story_title">Whole Story Back Translation</string>
     <string name="back_translation_title">Back Translation</string>
     <string name="title_activity_story_templates">Story Templates</string>
+    <string name="title_activity_wordlink_list">Word Links List</string>
 
     <!-- String names for registration -->
     <string name="registration_language_header">Language Information</string>
@@ -165,6 +166,19 @@
     <string name="translate_revise_playback_no_lwc_audio">Could not find narration audio</string>
     <string name="translate_revise_playback_lwc_audio">Playing narration audio</string>
     <string name="translate_revise_play_narration_audio">Play narration audio</string>
+
+    <!-- WordLink Tool -->
+    <string name="wordlink_submit_backtranslation_hint">word-for-word backtranslation / transliteration</string>
+    <string name="wordlink_close">Close</string>
+    <string name="wordlink_notes">MEANING NOTES. DEFINITIONS:</string>
+    <string name="wordlink_related_terms">RELATED (BUT DIFFERENT) TERMS:</string>
+    <string name="wordlink_other_langauge_examples">OTHER LANGUAGE EXAMPLES:</string>
+    <string name="wordlink_fill_with_audio_comment">Fill with Audio Comment</string>
+    <string name="wordlink_backtranslation">Backtranslation</string>
+    <string name="wordlink_none">None</string>
+    <string name="wordlink_list_help">None</string>
+    <string name="wordlinks_csv_read_error">Error reading word links CSV file</string>
+    <string name="wordlinks_json_read_error">Error reading word links JSON file</string>
 
     <!-- Voice Studio Phase -->
     <string name="voice_studio_edit_text_hint">Write story text for videos with included text.</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ org.gradle.jvmargs=-Xmx1024m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.enableJetifier=true
+android.enableUnitTestBinaryResources=false
 android.useAndroidX=true
 kapt.incremental.apt=true
 


### PR DESCRIPTION
Integrate Cedarville Word Links turnover into the current sillsdev:develop baseline.  Disable processing of column D & E in the Word Links spread sheet.

The following test procedure was used on an Android 11 Pixel 5 phone using a debug version of Story Producer generated by Android Studio.

The following test procedure was also used on an Android 9 Pixel 2 Android Studio emulator using the team city continuous integration build (SP-3.0.6-pull-592.288.apk)

![image](https://user-images.githubusercontent.com/78509270/131589865-f76d0b3e-5465-4f30-9c9e-d0ef05f130ea.png)

![image](https://user-images.githubusercontent.com/78509270/131589996-fd58714e-20df-40b5-ae22-6eb1a8bddde3.png)
