### PR TITLE
Fix broken README link to template files on Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ save in the root directory.
     * Connect to your device via USB (it will show as a drive on your computer)
         * If it does not show up as a drive, swipe down from the top.  You should see a notification: USB for charging.  Touch it.  Select USB for file transfer.
     * Download StoryProducer_v[most recent version].apk and copy the file onto your phone or tablet. Use your file manager on your Android device to open the apk and install it onto your device.
-    * Download the [template folders](https://drive.google.com/drive/folders/0Bw7whhMtjqJTVkljWlY0akZXeDg?usp=sharing) to your computer
+    * Download the [template folders](https://drive.google.com/drive/folders/1CxpggJUJ6QPnNgb3Veh9r7SWiLfPKCDj?usp=sharing) to your computer
     * Copy the unzipped templates folder to your SD card.  A good directory would be **\[thumb drive\]/SP Templates**
     * Open Story Producer and select the "SP Templates" which is the folder that all the templates are in.  (Not the folder of a specific template, but the folder that contains the templates.)
     * Continue with registration and use the app!


### PR DESCRIPTION
I found a Google Drive link [in a strings.xml file](https://github.com/alexcwatt/StoryProducer/blob/9a3a045bd740436fb9a99424e7be081c273b2617/app/src/main/res/values/strings.xml#L105) that I think is the accurate link.