### PR TITLE
SP571 Easy Access to Google Drive Templates

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.sil.storyproducer.R
 import org.sil.storyproducer.activities.BaseActivity
+import org.sil.storyproducer.activities.WelcomeDialogActivity
 import org.sil.storyproducer.controller.storylist.StoryPageAdapter
 import org.sil.storyproducer.controller.storylist.StoryPageTab
 import org.sil.storyproducer.model.Phase
@@ -190,7 +191,24 @@ class MainActivity : BaseActivity(), Serializable {
 
         when (menuItem.itemId) {
             R.id.nav_workspace -> {
-                showSelectTemplatesFolderDialog()
+                // DKH - 11/8/2021
+                // Issue #571: Add a menu item for accessing templates from Google Drive
+                // Instead of adding a new menu item, repurpose the "Select 'SP Templates' Folder"
+                // option in the hamburger menu in the "Story Templates" screen.
+                // The user selects "Select 'SP Templates' Folder" from the hamburger menu and the
+                // "Welcome Dialog Screen" appears.  The user then selects the option  to
+                // "Use Google Drive and download story Templates" in the "Welcome Dialog Screen.
+                // This places Story Producer in the background and Google Drive interface appears.
+                // The user downloads the templates into the download directory on the phone and
+                // then uses the folder app to create a new folder.  The user then moves the files
+                // from the download folder into a target folder (user may create a new folder for
+                // the newly downloaded templates or use an existing folder).
+                // The user then brings Story Producer to
+                // the foreground.  The user then selects "Select 'SP Templates' Folder" at the
+                // bottom of the "Welcome Dialog Screen" and proceeds to process the target folder.
+                // Previous call interface: showSelectTemplatesFolderDialog()
+                // New call interface to bring up "Welcome Dialog Screen"
+                startActivity(Intent(this, WelcomeDialogActivity::class.java))
             }
             R.id.nav_demo -> {
                 Workspace.addDemoToWorkspace(this)

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -200,7 +200,7 @@ class MainActivity : BaseActivity(), Serializable {
                 // "Use Google Drive and download story Templates" in the "Welcome Dialog Screen.
                 // This places Story Producer in the background and Google Drive interface appears.
                 // The user downloads the templates into the download directory on the phone and
-                // then uses the folder app to create a new folder.  The user then moves the files
+                // then uses the Android  folder app to moves the files
                 // from the download folder into a target folder (user may create a new folder for
                 // the newly downloaded templates or use an existing folder).
                 // The user then brings Story Producer to

--- a/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
@@ -56,8 +56,7 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 // "Use Google Drive and download story Templates" in the "Welcome Dialog Screen.
                 // This places Story Producer in the background and Google Drive interface appears.
                 // The user downloads the templates into the download directory on the phone and
-                // then uses the Android folder app to create a new folder.
-                // The user then moves the files
+                // then uses the Android folder app to moves the files
                 // from the download folder into a target folder (user may create a new folder for
                 // the newly downloaded templates or use an existing folder).
                 // The user then brings Story Producer to

--- a/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.widget.AdapterView
 import org.sil.storyproducer.activities.BaseActivity
 import org.sil.storyproducer.controller.MainActivity
+import org.sil.storyproducer.activities.WelcomeDialogActivity
 import org.sil.storyproducer.model.Workspace
 
 class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.OnItemClickListener {
@@ -46,7 +47,29 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 activity.showMain()
             }
             3 -> {
-                activity.showSelectTemplatesFolderDialog()
+                // DKH - 11/8/2021
+                // Issue #571: Add a menu item for accessing templates from Google Drive
+                // Instead of adding a new menu item, repurpose the "Select 'SP Templates' Folder"
+                // option in the hamburger menu in the Phase screen (eg, Learn, Translate + Revise, etc)
+                // The user selects "Select 'SP Templates' Folder" from the hamburger menu and the
+                // "Welcome Dialog Screen" appears.  The user then selects the option  to
+                // "Use Google Drive and download story Templates" in the "Welcome Dialog Screen.
+                // This places Story Producer in the background and Google Drive interface appears.
+                // The user downloads the templates into the download directory on the phone and
+                // then uses the Android folder app to create a new folder.
+                // The user then moves the files
+                // from the download folder into a target folder (user may create a new folder for
+                // the newly downloaded templates or use an existing folder).
+                // The user then brings Story Producer to
+                // the foreground.  The user then selects "Select 'SP Templates' Folder" at the
+                // bottom of the "Welcome Dialog Screen" and proceeds to process the target folder.
+                // Previous call interface: showSelectTemplatesFolderDialog()
+                // New call interface to bring up "Welcome Dialog Screen"
+                activity.startActivity(Intent(activity.applicationContext, WelcomeDialogActivity::class.java))
+                // since this menu selection is in a Phase activity, exit the phase activity
+                // which will force the control to the "Story Template" screen in the
+                // main activity
+                activity.finish()
             }
             4 -> {
                 Workspace.addDemoToWorkspace(activity)


### PR DESCRIPTION
In response to SP #571, this is a simple work around for ~~allowing the user~~ easy access to download more templates from the Google drive  anytime during the execution of Story Producer.  ~~Previously, the user could only download templates during Story Producer installation.~~ Previously, the app provides the download link only on the Welcome screen at installation. (After that, the user would have to go to the instruction documents to get the link.)

**Solution:** 
Instead of adding a new menu item, repurpose the "Select 'SP Templates' Folder" option in the hamburger menu in the "Phase screen" or the "Story Template Screen". The user selects "Select 'SP Templates' Folder" from the hamburger menu and the "Welcome Dialog Screen" appears.  The user then selects the option  to "Use Google Drive and download story Templates" in the "Welcome Dialog Screen".  This places Story Producer in the background and Google Drive interface appears.  The user downloads the templates into the download directory on the phone and then uses the Android folder app to  moves the files from the download folder into a target folder (user may create a new folder for the newly downloaded templates or use an existing folder).  The user then brings Story Producer to the foreground.  The user then selects "Select 'SP Templates' Folder" at the bottom of the "Welcome Dialog Screen" and proceeds to process the target folder.

**Testing:** 
Solution was tested on a Pixel 5 Android 12 phone using Android Studio Debug build.
Solution was tested on a Android Studio Pixel 2 Android 9 emulator using Android Studio Debug Build.
Espresso tests were run on Pixel 2 Android 9 emulator using Android Studio Debug Build (all tests passed).
Solution was tested on a Pixel 5 Android 12 phone using Team City Continuous build 307.
Solution was test on a Android Studio Pixel 2 Android 9 Emulator using Team City Continuous build 307.