### PR TITLE
SP550-SharePhase Scrolling Fix

### DIFF
--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -58,7 +58,7 @@
             <ListView
                 android:id="@+id/videos_list"
                 android:layout_width="match_parent"
-                android:layout_height="604dp">
+                android:layout_height="384dp">
 
             </ListView>
 

--- a/app/src/main/res/layout/exported_video_row.xml
+++ b/app/src/main/res/layout/exported_video_row.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="40dp">
+    android:layout_height="48dp"
+    android:layout_marginStart="4dp"
+    android:orientation="horizontal">
 
     <ImageButton
         android:id="@+id/video_play_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_margin="8dp"
+        android:layout_marginLeft="4dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginRight="4dp"
+        android:layout_marginBottom="12dp"
         android:backgroundTint="@color/transparent"
         android:contentDescription="@string/play"
         android:src="@drawable/ic_play_arrow_white_48dp" />
@@ -18,7 +22,10 @@
         android:id="@+id/file_share_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_margin="8dp"
+        android:layout_marginLeft="4dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginRight="4dp"
+        android:layout_marginBottom="12dp"
         android:backgroundTint="@color/transparent"
         android:contentDescription="@string/share"
         android:src="@drawable/ic_share_white_24dp" />
@@ -35,7 +42,10 @@
         android:id="@+id/file_delete_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_margin="8dp"
+        android:layout_marginLeft="4dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginRight="4dp"
+        android:layout_marginBottom="12dp"
         android:backgroundTint="@color/transparent"
         android:contentDescription="@string/share"
         android:src="@drawable/ic_delete_forever_white_36dp" />


### PR DESCRIPTION
**Problem:**  The geometry for the Share Phase Screen is incorrect causing incorrect scrolling and lines to overlap within a single video name when it wraps to the next line.

**Solution:** Update the geometry of the Share Phase Screen to properly scroll and to properly line wrap.

Before fix:
![image](https://user-images.githubusercontent.com/78509270/141213406-81075db4-af39-4a48-a9ca-d071e8fb90e6.png)


After fix:
![image](https://user-images.githubusercontent.com/78509270/141213443-22fc462a-8e5d-4fc1-8938-ee79abbb5018.png)
