### PR TITLE
WIP - Explore Marathon to run tests

### DIFF
--- a/Marathonfile
+++ b/Marathonfile
@@ -1,0 +1,6 @@
+name: "StoryProducer"
+outputDir: "build/reports/marathon"
+vendorConfiguration:
+  type: "Android"
+  applicationApk: "app/build/outputs/apk/debug/SP-debug.apk"
+  testApplicationApk: "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"


### PR DESCRIPTION
I've been investigating how to easily run Espresso tests on multiple emulators. I came across a handful of possibilities ([Fastlane](https://fastlane.tools/) but it seems to do much more than just this, [Android test orchestrator](https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator), and [Spoon by Square](https://github.com/square/spoon) but it seems dead.

This is a draft until I can get it all working.

---

Notes:

* Install Marathon
* Set ANDROID_HOME environment variable (e.g., `export ANDROID_HOME=/Users/alex/Library/Android/sdk/`)