### PR TITLE
SP-606 Add help for back Translation

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/adapter/RecordingsListAdapter.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/adapter/RecordingsListAdapter.kt
@@ -115,8 +115,21 @@ class RecordingsListAdapter(val values: MutableList<String>?, private val listen
             // Apply layout properties
             newName.layoutParams = params
 
+            // 11/13/2021 - DKH, Issue 606, Wordlinks quick fix for text back translation
+            // This piece of software is used in multiple places in Story Producer
+            // Grab the default instructions for data entry
+            // This is something like: "Choose a new name"
+            var title = itemView.context.getString(R.string.rename_title)
+
+            // If this is Wordlinks, use instructions that are geared toward Wordlinks
+            when(Workspace.activePhase.phaseType){
+                PhaseType.WORD_LINKS -> {
+                    title = itemView.context.getString(R.string.rename_title_wordlinks)
+                }
+            }
+
             val dialog = AlertDialog.Builder(itemView.context)
-                    .setTitle(itemView.context.getString(R.string.rename_title))
+                    .setTitle(title)
                     .setView(newName)
                     .setNegativeButton(itemView.context.getString(R.string.cancel), null)
                     .setPositiveButton(itemView.context.getString(R.string.save)) { _, _ ->

--- a/app/src/main/java/org/sil/storyproducer/model/Phase.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Phase.kt
@@ -139,6 +139,16 @@ class Phase (val phaseType: PhaseType) {
         }
     }
 
+    // 11/13/2021 - DKH, Issue 606, Wordlinks quick fix for text back translation
+    // This piece of software is used in multiple places in Story Producer
+    // This instructional string is appended to the generated display name
+    fun getDisplayNameAdditionalInfo() : String {
+        return when (phaseType) {
+            PhaseType.WORD_LINKS       -> " --> Press and hold to back translate"
+            else -> ""
+        }
+    }
+
     /**
      * Get file-safe name for phase, used to save audio files
      * @return String

--- a/app/src/main/java/org/sil/storyproducer/tools/file/AudioFiles.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/file/AudioFiles.kt
@@ -3,6 +3,7 @@ package org.sil.storyproducer.tools.file
 
 import android.content.Context
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.sil.storyproducer.R
 import org.sil.storyproducer.model.*
 import org.sil.storyproducer.model.PROJECT_DIR
 import java.util.*
@@ -165,7 +166,13 @@ fun createRecordingCombinedName() : String {
                     FirebaseCrashlytics.getInstance().recordException(e)
                 }
             }
-            "${Workspace.activePhase.getDirectorySafeName()} ${maxNum+1}|${Workspace.activeDir}/${Workspace.activeFilenameRoot}_${Date().time}$AUDIO_EXT"
+            // 11/13/2021 - DKH, Issue 606, Wordlinks quick fix for text back translation
+            // Append the generated instructional string to the display name.
+            var displayName = "${Workspace.activePhase.getDirectorySafeName()} ${maxNum+1}" +
+                    Workspace.activePhase.getDisplayNameAdditionalInfo()
+
+            // create the combined string of display name and audio file location
+            "${displayName}|${Workspace.activeDir}/${Workspace.activeFilenameRoot}_${Date().time}$AUDIO_EXT"
         }
         else -> {""}
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,9 @@
     <string name="registration_error_message">Please provide an database email address</string>
     <string name="registration_saved_successfully">Registration information saved!</string>
     <string name="registration_robin_rempel_email">SPapp_info@sil.org</string>
-    <string name="rename_title">Choose a new name</string>
+    <string name="rename_title">Choose a new name</string><!-- Default instructions on how to enter data -->
+    <!-- For Word links, give user more instruction on how to enter the data -->
+    <string name="rename_title_wordlinks">Type a back translation or spell the name.</string>
     <string name="recordings_title">Recordings</string>
     <string name="backTranslation_recordings_title">Back Translation Recordings </string> <!-- for new backtranslation phase -->
     <string name="consultant_password_title">Consultant Password</string>


### PR DESCRIPTION
**Per Issue #606:** "Wordlinks quick fix for text back translation #606", this pull request swaps out the place holder text on the Worklinks audio file names & editable text box with the following text:

Replace "WordLinks 1" with "WordLinks 1 -> Press and hold to back translate" on the WordLinks window that contains the audio file name.

Replace "Choose a new name"  with "Type a back translation or spell the name" on the WorkLinks editable text box.

**Testing:**  Changes were tested on the following platforms:
Google Pixel 5 phone running Android 12
Google Pixel 3 emulator running Android 8
Motorola Phone running Android 9.

