### PR TITLE
SP 611: Create Word Links directory and allow CSV files to have different names

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -156,7 +156,11 @@ object Workspace {
             importWordLinksFromJsonFiles(context, wordLinksDir)
             mapTermFormsToTerms()
             buildWLSTree()
+        }else{
+            // DKH - 11/19/2021 Issue #661 Create Word Links CSV directory if it does not exist
+            workdocfile.createDirectory(WORD_LINKS_DIR)
         }
+
     }
 
     private fun importWordLinksFromCSV(context: Context, wordLinksDir: DocumentFile){

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="wordlink_list_help">None</string>
     <string name="wordlinks_csv_read_error">Error reading word links CSV file</string>
     <string name="wordlinks_json_read_error">Error reading word links JSON file</string>
+    <string name="wordlinks_no_csv_file">No Valid CSV WordLinks File Specified</string> <!-- SP611 CSV Error handling -->
+    <string name="wordlinks_multiple_csv_files">Detected multiple Word Links CSV Files.\nUsing:\t</string> <!-- SP611 CSV Error handling -->
 
     <!-- Voice Studio Phase -->
     <string name="voice_studio_edit_text_hint">Write story text for videos with included text.</string>


### PR DESCRIPTION
Per Issue #611, update Story Producer to create the Word Links Directory if it does not exist and allow the CSV file that contains the word links data to have a variable name.  This name begins with "wordlinks" and ends with ".csv", e.g.: worklinks-DKH.csv.

Testing:  This fix was successfully tested on an Android 12, Pixel 5 phone and on an Android 8, Pixel 3 Android Studio emulation.