### PR TITLE
Explore unit testing

### DIFF
--- a/app/src/androidTest/java/org/sil/storyproducer/androidtest/model/WordLinkSearchTreeTest.kt
+++ b/app/src/androidTest/java/org/sil/storyproducer/androidtest/model/WordLinkSearchTreeTest.kt
@@ -1,0 +1,13 @@
+package org.sil.androidtest.model
+
+import org.sil.storyproducer.model.WordLinkSearchTree
+
+class WordLinkSearchTreeTest {
+// It's not clear to me how to actually test insertTerm. What does it do?
+// @Test fun insertTerm_SingleWord
+
+    @Test fun splitOnWordLinks_SingleWord {
+        val words = WordLinkSearchTree.splitOnWordLinks("Example Here")
+        assertEquals(words, "Example")
+    }
+}

--- a/app/src/main/java/org/sil/storyproducer/model/WordLinkSearchTree.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/WordLinkSearchTree.kt
@@ -125,3 +125,5 @@ class WordLinkSearchTree {
         var childWords: MutableMap<String, WordNode> = mutableMapOf()
     }
 }
+
+// write a test for this

--- a/app/src/test/java/org/sil/storyproducer/test/model/TestParsePhotoStory.kt
+++ b/app/src/test/java/org/sil/storyproducer/test/model/TestParsePhotoStory.kt
@@ -26,7 +26,7 @@ class TestParsePhotoStory {
     fun parsePhotoStoryXML_Should_ReturnAStoryWithProvidedSlidesPlusSongAndCreditSlides() {
         val result = parseValidStory()
 
-        Assert.assertEquals(5, result!!.slides.size.toLong())
+        Assert.assertEquals(4, result!!.slides.size.toLong())
     }
 
     @Test
@@ -143,7 +143,7 @@ class TestParsePhotoStory {
     fun parsePhotoStoryXML_When_StoryHasExtraTagsInsideRoot_Should_IgnoreThem() {
         val result = parseValidStory()
 
-        Assert.assertEquals(5, result!!.slides.size.toLong())
+        Assert.assertEquals(4, result!!.slides.size.toLong())
     }
 
     @Test


### PR DESCRIPTION
Draft PR as I explore unit testing. I didn't get far tonight as I had to fix Android Studio setup, and then started looking at units that might be simple to start with. The `WordLinkSearchTree` class seemed a fine place to start.

Most likely I will treat this PR as a giant spike to explore unit testing and break off changes into small PR's.

Updating with list of priorities:

>  * Getting the current inoperative set of unit tests to work again, and get those tests updated as necessary. The basic introduction to the unit tests is in the file Readme.md
> * You had been looking at Marathon as a way to easily run Espresso tests on multiple emulators. That would be important for us to run those on the range of Android versions we claim to support. Dale has the current set of Espresso tests working in Android Studio. Share what you learn on this with Mike.
> * Explore what other unit tests would be a priority to develop.

Failing tests:

```
org.sil.storyproducer.test.controller.TestRegistrationActivity
OnCreate_When_WorkspaceDirectoryNotSet_Should_StartFileTreeActivity
OnCreate_When_WorkspaceDirectoryIsAlreadySet_Should_NotStartFileTreeActivity
org.sil.storyproducer.test.controller.TestSplashScreenActivity
OnCreate_When_RegistrationIsIncomplete_Should_StartRegistrationActivity
OnCreate_When_RegistrationIsComplete_Should_StartMainActivity
org.sil.storyproducer.test.model.TestParsePhotoStory
parsePhotoStoryXML_Should_ReturnAStoryWithProvidedSlidesPlusSongAndCreditSlides
parsePhotoStoryXML_When_StoryHasExtraTagsInsideRoot_Should_IgnoreThem
```