### PR TITLE
SP571-From MainActivity, user can download templates from URL

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/activities/WelcomeDialogActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/activities/WelcomeDialogActivity.kt
@@ -12,6 +12,7 @@ import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
 import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Workspace
 
 /**
  * Activity creates the welcome screen dialog, used when the Workspace's project directory
@@ -62,7 +63,15 @@ class WelcomeDialogActivity : BaseActivity() {
     }
 
     private fun buildMessage(): Spanned {
-        val message = getString(R.string.welcome_screen_select_template_folder)
+        // DKH - 01/15/2022 Issue #571: Add a menu item for accessing templates from Google Drive
+        // The strings.xml file contains the "Welcome Screen" html in the following string:
+        // <string name="welcome_screen_select_template_folder">).
+        // This update moved the actual URL for the template folder from the strings.xml file
+        // to the Workspace object.  A place holder string was placed in the "Welcome Screen" html,
+        // so, update the place holder string with the actual URL before we display the
+        // "Welcome Screen" to the user.
+        val message = getString(R.string.welcome_screen_select_template_folder).
+            replace(Regex(Workspace.URL_FOR_TEMPLATES_PLACE_HOLDER), Workspace.URL_FOR_TEMPLATES)
         return if (Build.VERSION.SDK_INT >= 24) {
             Html.fromHtml(message, 0)
         } else {

--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
@@ -200,6 +201,15 @@ class MainActivity : BaseActivity(), Serializable {
             }
             R.id.nav_word_link_list -> {
                 showWordLinksList()
+            }
+            R.id.nav_more_templates -> {
+                // DKH - 01/15/2022 Issue #571: Add a menu item for accessing templates from Google Drive
+                // A new menu item was added that opens a URL for the user to download templates.
+                // If we get here, the user wants to browse for more templates, so,
+                // open the URL in an new activity
+                val openURL = Intent(android.content.Intent.ACTION_VIEW)
+                openURL.data = Uri.parse(Workspace.URL_FOR_TEMPLATES)
+                startActivity(openURL)
             }
             R.id.nav_stories -> {
                 // Current fragment

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -38,6 +38,21 @@ internal val WORD_LINKS_CSV_REGEX = WORK_LINKS_CSV_REGEX_STRING.toRegex()
 
 
 object Workspace {
+    // DKH - 01/15/2022 Issue #571 Add a menu item for accessing templates from Google Drive
+    // The strings.xml file contains the "Welcome Screen" html in the following string:
+    // <string name="welcome_screen_select_template_folder">).  Embedded in the string is
+    // the URL to the the location of the shared drive that contains the templates.
+    // Instead of duplicating the same string, remove the reference from the strings.xml file and
+    // update the "Welcome Screen" html with the URL before display of the "Welcome Screen"
+    // ( WelcomeDialogActivity.kt).  We will have different strings.xml file for each
+    // language and by having the URL defined here, we never have to update the different strings.xml
+    // files.
+    const val URL_FOR_TEMPLATES = "https://drive.google.com/drive/folders/1CxpggJUJ6QPnNgb3Veh9r7SWiLfPKCDj?usp=sharing"
+    // These are the place holder strings in the "Welcome Screen" html.  Before displaying the
+    // "Welcome Screen", replace this place holder strings with the URL_FOR_TEMPLATES
+    const val URL_FOR_TEMPLATES_PLACE_HOLDER = "URL_FOR_TEMPLATES_PLACE_HOLDER"
+    // End Issue #571
+
     var workdocfile = DocumentFile.fromFile(File(""))
         set(value) {
             field = value

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -5,11 +5,14 @@
             android:id="@+id/nav_stories"
             android:title="@string/title_activity_story_templates" />
         <item
-            android:id="@+id/nav_word_link_list"
-            android:title="@string/title_activity_wordlink_list" />
-        <item
             android:id="@+id/nav_registration"
             android:title="@string/update_registration" />
+        <item
+            android:id="@+id/nav_more_templates"
+            android:title="@string/more_templates" />
+        <item
+            android:id="@+id/nav_word_link_list"
+            android:title="@string/title_activity_wordlink_list" />
         <item
             android:id="@+id/nav_workspace"
             android:title="@string/update_workspace" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,7 +284,7 @@
     <string name="update_workspace">Select \'SP Templates\' folder</string>
     <string name="cancelling">Cancelling &#8230;</string>
     <string name="copy_demo">Add demo to story list</string>
-    <string name="more_templates">More Templates</string>
+    <string name="more_templates">Download More Templates</string>
 
     <!-- Main Story Page -->
     <string name="all_stories_tab">All Stories</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
         &lt;font color=\"green\">&lt;b>SD card&lt;/b>&lt;/font>.</string>
     <string name="stories_not_found_in_progress">There are no stories in progress.</string>
     <string name="stories_not_found_completed">There are no completed stories.</string>
+    <!--  Issue #571, for welcome_screen_select_template_folder, replace template URL with a place holder. Move URL to workspace object -->
     <string name="welcome_screen_select_template_folder">
         Story Producer is different from typical apps.
         You must first create a folder on your SD card (preferred) where the story template files must be downloaded by you.&lt;br>
@@ -105,7 +106,7 @@
         To prepare your SD card&#8230;&lt;br>
         \t\tGo &lt;a href="https://docs.google.com/document/d/1Jw73VlLmIyJgoFM3EOLyqGZyO50pOqXiSmsuLuq_u34/edit">HERE&lt;/a> for detailed instructions&lt;br>
         \t\tOR follow these summary instructions:&lt;br>
-        1. Use Google Drive and download story templates from &lt;a href="https://drive.google.com/drive/folders/1CxpggJUJ6QPnNgb3Veh9r7SWiLfPKCDj?usp=sharing">HERE&lt;/a>&lt;br>
+        1. Use Google Drive and download story templates from &lt;a href="URL_FOR_TEMPLATES_PLACE_HOLDER">HERE&lt;/a>&lt;br>
         2. Use a Files app to create a folder on the SD card, and name it &lt;font color=\"green\">SP Templates&lt;/font>&lt;br>
         3. With the Files app, Move or Copy story template(s) to the &lt;font color=\"green\">SP Templates&lt;/font> folder&lt;br>&lt;br>
         After you have prepared the &lt;font color=\"green\">SP Templates&lt;/font> folder, proceed:
@@ -283,6 +284,7 @@
     <string name="update_workspace">Select \'SP Templates\' folder</string>
     <string name="cancelling">Cancelling &#8230;</string>
     <string name="copy_demo">Add demo to story list</string>
+    <string name="more_templates">More Templates</string>
 
     <!-- Main Story Page -->
     <string name="all_stories_tab">All Stories</string>


### PR DESCRIPTION
Per Issue #571, update Story Producer to allow a user to load additional templates from the MainActivity via a URL (which points to a Google shared drive).  This URL is referenced in the "Welcome Screen" and when a user picks a menu option from the MainActivity.  Previously, the URL was embedded in the html for the "Welcome Screen".  To avoid duplication, the URL was moved to the Workspace object where it can be inserted into the "Welcome Screen" html before display or used when the "More Templates"  menu option is selected from the MainActivity.

**Testing:** 
Using an Android Studio debug build, templates were downloaded  from the "Welcome Screen" and the MainActivity via the shared drive URL. Test were run on an Android11 Pixel 5 phone and on an Android 9 Pixel 2 emulator.

Successfully ran Espresso tests on a Pixel 2 Android 9 emulator using the debug build.

**NEW MENU PICK (As described in Issue #571):**
![image](https://user-images.githubusercontent.com/78509270/149854999-b0217d4a-5fff-4f98-8e42-d0d7069c610b.png)


**Display of Shared Drive after menu pick:**
![image](https://user-images.githubusercontent.com/78509270/149847051-18d0d81b-6641-4c69-bec7-d5ccf2bd85d4.png)
