### PR TITLE
SP571-Added URL template download to Phase menu

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -206,10 +206,8 @@ class MainActivity : BaseActivity(), Serializable {
                 // DKH - 01/15/2022 Issue #571: Add a menu item for accessing templates from Google Drive
                 // A new menu item was added that opens a URL for the user to download templates.
                 // If we get here, the user wants to browse for more templates, so,
-                // open the URL in an new activity
-                val openURL = Intent(android.content.Intent.ACTION_VIEW)
-                openURL.data = Uri.parse(Workspace.URL_FOR_TEMPLATES)
-                startActivity(openURL)
+                // open the URL in a new activity
+                Workspace.startDownLoadMoreTemplatesActivity(this)
             }
             R.id.nav_stories -> {
                 // Current fragment

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -3,6 +3,7 @@ package org.sil.storyproducer.model
 import WordLinksCSVReader
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
@@ -163,6 +164,14 @@ object Workspace {
         } catch (e: Exception) {
             Log.e("setupWorkspacePath", "Error setting up new workspace path!", e)
         }
+    }
+    // DKH - 01/26/2022 Issue #571: Add a menu item for accessing templates from Google Drive
+    // A new menu item was added that opens a URL for the user to download templates.
+    // This is used in both the MainActivity menu (Story Templates display) and the Phase menus
+    fun startDownLoadMoreTemplatesActivity(context: Context){
+        val openURL = Intent(Intent.ACTION_VIEW)
+        openURL.data = Uri.parse(Workspace.URL_FOR_TEMPLATES)
+        context.startActivity(openURL)
     }
 
     private fun importWordLinks(context: Context) {

--- a/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/DrawerItemClickListener.kt
@@ -24,9 +24,6 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 activity.finish()
             }
             1 -> {
-                activity.showWordLinksList()
-            }
-            2 -> {
                 // 06/14/2021 - DKH, Issue 407, Pull Request 561 - Merge into Latest sillsdev
                 // The new Filter layout for the Story Templates broke the capability to launch
                 // the showRegistration () from the calling activity.  SP uses the paradigm of
@@ -45,13 +42,23 @@ class DrawerItemClickListener(private val activity: BaseActivity) : AdapterView.
                 Workspace.showRegistration = true
                 activity.showMain()
             }
+            2 -> {
+                // DKH - 01/23/2022 Issue #571: Add a menu item for accessing templates from Google Drive
+                // A new menu item was added that opens a URL for the user to download templates.
+                // If we get here, the user wants to browse for more templates, so,
+                // open the URL in a new activity
+                Workspace.startDownLoadMoreTemplatesActivity(activity)
+            }
             3 -> {
-                activity.showSelectTemplatesFolderDialog()
+                activity.showWordLinksList()
             }
             4 -> {
-                Workspace.addDemoToWorkspace(activity)
+                activity.showSelectTemplatesFolderDialog()
             }
             5 -> {
+                Workspace.addDemoToWorkspace(activity)
+            }
+            6 -> {
                 activity.showAboutDialog()
             }
         }

--- a/app/src/main/res/values/global_menu_array.xml
+++ b/app/src/main/res/values/global_menu_array.xml
@@ -2,8 +2,9 @@
 <resources>
     <string-array name="global_menu_array">
         <item>@string/title_activity_story_templates</item>
-        <item>@string/title_activity_wordlink_list</item>
         <item>@string/update_registration</item>
+        <item>@string/more_templates</item>
+        <item>@string/title_activity_wordlink_list</item>
         <item>@string/update_workspace</item>
         <item>@string/copy_demo</item>
         <item>@string/about</item>


### PR DESCRIPTION
Per Issue #571, update Story Producer to allow a user to load additional templates.  Pull #619 allows a user to download additional story templates from the main menu.  This pull request allows a user to download additional story templates from any of the phases.

Testing:
Using an Android Studio debug build, templates were downloaded from the Phase menu via the shared drive URL. Test were run on an Android11 Pixel 5 phone and on an Android 9 Pixel 2 emulator.

Successfully ran Espresso tests on a Pixel 2 Android 9 emulator using the debug build.

New Menu in Phase Activity:
![image](https://user-images.githubusercontent.com/78509270/151287422-1983eecd-b9a5-460b-a176-4efda0c159a8.png)
