### PR TITLE
SP590, SP552, Pull 558:  Add registration help and update help html documents

### DIFF
--- a/app/src/main/assets/accuracy_check.html
+++ b/app/src/main/assets/accuracy_check.html
@@ -3,133 +3,131 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:10:36.629000000"/>
+	<meta name="changed" content="2022-01-11T16:49:05.701000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: always; page-break-after: auto"><a name="__DdeLink__817_2798436883"></a>
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Accuracy
-Check</span></b></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-A local </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">consultant
-or accuracy checker </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">will
+<body lang="en-US" dir="ltr"><p align="left" style="font-variant: normal; font-style: normal; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always; page-break-after: auto">
+<font color="#000000"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Accuracy
+Check</span></b></font></font></font></p>
+<p align="left" style="font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent; page-break-before: auto; page-break-after: auto"><a name="docs-internal-guid-e9dbc50e-7fff-0eaf-c97b-090364f925bc"></a>
+<font color="#000000"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+A local </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">consultant
+or accuracy checker </span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">will
 hold the phone and facilitate the accuracy check. &nbsp;The accuracy
-checker may request to have </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">one
-or more previously uninvolved local language speakers (ULSs)</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font size="3" style="font-size: 12pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-</span></span></span></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">to
+checker may request to have </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">one
+or more previously uninvolved local language speakers (ULSs)</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">to
 assist with back translations and answering comprehension and
-inference questions. One of the original story </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">translators
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">should
-also be available to make any necessary revisions.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">accuracy
-check </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">phase
-is to check and </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">approve
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">that
-the story translation draft is </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">accurate
-a</span></b></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>nd
-meaningful</b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Review
-	history logs for each slide. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
-	accuracy checker can tap the</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	&ldquo;sandwich&rdquo; (three-lines) </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">button
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">on
-	the bottom of </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">each
-	slide to bring up a history log of translation activities which have
-	taken place in the process of translating that slide. This log of
-	activities can be sorted by tapping the heading of each color-coded
-	column. If it is noted that the translators did not do a thorough
-	job of translation and community checking, and if the translation is
-	rough, it is appropriate for the accuracy checker to ask the </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">primary
-	translator to go back and do any activities which were skipped over.
-	Utilize the history logs as a training tool.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Listen
-	to the translation draft. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">For
-	the whole story, the accuracy checker plays and swipes, plays and
-	swipes for the ULSs to listen to the entire story. Repeat as
-	necessary. If the accuracy checker does not know the language, the
-	ULSs can give an oral back-translated summary of the story.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Comprehend
-	and compare</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">For
-	each slide, the accuracy checker will play and pause, play and pause
-	to get an oral back-translation phrase by phrase. The accuracy
-	checker can ask any number of comprehension or inference questions
-	until s/he is convinced that the translation for that slide is clear
-	and accurate without any misleading information in comparison to the
-	source text displayed below the picture and/or in comparison to the
-	Bible reference from which the source text comes. Note: also check
-	the lyrics of the song for </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">Biblical
-	accuracy and relevance to the story</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Review
-	key terms. </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">At
-	any time during the accuracy check, the checker can tap on a
-	hyperlinked (underlined) term or name to open the Word Links tool to
-	review the audio renderings and text back-translations/transliterations of the terms in the local language.
-	Discuss and revise these terms as necessary.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Revise
-	as necessary. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
-	any revisions are needed, the consultant will discuss the issue with
-	the translator(s). The translator can then swipe up or tap (use the
-	drop down menu) to the TRANSLATE phase and revise that slide. Then
-	sw</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">ipe
-	or tap to</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	return to the Accuracy Check phase. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Tick
-	each slide as they are approved.</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
-	accuracy checker can tap the gray tick mark button at the bottom of
-	the screen to turn it green when s/he feels a slide </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">has
-	been appropriately drafted</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Approve
-	the story.</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">When
-	all the slides have been ticked green, the accuracy checker will
-	type in the password to approve the translation draft and unlock the
-	RECORDING STUDIO phase.</span></span></span></font></font></span></font></span></font></font></font></p>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
+inference questions. &nbsp;One of the original story </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">translators
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">should
+also be available to make any necessary revisions.</span></span></font></font></span></span></font></p>
+<p><br/>
 <br/>
 
 </p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span></font></font></font>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+&nbsp;The purpose of the accuracy check phase is to check and </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">approve
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">that
+the story translation draft is </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">accurate
+and meaningful</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">.</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
 </p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Review
+	history logs for each slide.&nbsp; </span></b><span style="background: transparent">The
+	accuracy checker can tap the &ldquo;sandwich&rdquo; (three-lines)
+	button on the bottom of each slide to bring up a history log of
+	translation activities which have taken place in the process of
+	translating that slide. &nbsp;This log of activities can be sorted
+	by tapping the heading of each color-coded column.&nbsp; If it is
+	noted that the translators did not do a thorough job of translation
+	and community checking, and if the translation is rough, it is
+	appropriate for the accuracy checker to ask the primary translator
+	to go back and do any activities which were skipped over.&nbsp;
+	Utilize the history logs as a training tool.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Listen
+	to the translation draft. </span></b><span style="background: transparent">&nbsp;For
+	the whole story, the accuracy checker plays and swipes, plays and
+	swipes for the ULSs to listen to the entire story. &nbsp;Repeat as
+	necessary. If the accuracy checker does not know the language, the
+	ULSs can give an oral back-translated summary of the story.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Comprehend
+	and compare</span></b><span style="background: transparent">.&nbsp;
+	For each slide, the accuracy checker will play and pause, play and
+	pause to get an oral back-translation phrase by phrase. &nbsp;The
+	accuracy checker can ask any number of comprehension or inference
+	questions until s/he is convinced that the translation for that
+	slide is clear and accurate without any misleading information in
+	comparison to the source text displayed below the picture and/or in
+	comparison to the Bible reference from which the source text comes.
+	&nbsp;Note:&nbsp; also check the lyrics of the song for Biblical
+	accuracy and relevance to the story.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Review
+	key terms.&nbsp; </span></b><span style="background: transparent">At
+	any time during the accuracy check, the checker can tap on a
+	hyperlinked (underlined) term to open the Word Links (Key Term
+	Tracker) tool to review the audio renderings and text
+	back-translations/transliterations of the terms in the local
+	language. Discuss and revise these terms as necessary.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Revise
+	as necessary. </span></b><span style="background: transparent">&nbsp;If
+	any revisions are needed, the consultant will discuss the issue with
+	the translator(s). &nbsp;The translator can then swipe up or tap
+	(use the drop down menu) to the TRANSLATE + REVISE phase and revise
+	that slide. Then swipe or tap to return to the Accuracy Check
+	phase.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Tick
+	each slide as they are approved.</span></b><span style="background: transparent">
+	The accuracy checker can tap the grey tick mark button at the bottom
+	of the screen to turn it green when s/he feels a slide has been
+	appropriately drafted.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Approve
+	the story.</span></b><span style="background: transparent">&nbsp;
+	When all the slides have been ticked green, a password window will
+	pop up. The accuracy checker will type in the password to approve
+	the translation draft and unlock the </span><span style="background: transparent">VOICE</span><span style="background: transparent">
+	STUDIO phase and other production phases.</span></font></font></font></p>
+</ol>
+<p style="margin-left: 0.04in"><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
 <ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
 	accuracy checker should keep the password protected (a secret) from
-	other members of the story translation team. This helps to ensure
-	good accountability for the translation process.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
+	other members of the story translation team. &nbsp;This helps to
+	ensure good accountability for the translation process.</span></font></font></font></p>
+	<li><p><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
 	the accuracy checker forgets the password, send a text to the
 	Trainer to get some help. &nbsp;The Trainer&rsquo;s contact should
 	be in the registration information. Or send an email request for
-	assistance to </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#1155cc"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent"><a href="mailto:SPapp_info@sil.org"><span style="font-variant: normal"><font color="#1155cc"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">SPapp_info@sil.org</span></span></u></span></font></font></span></font></span></a></span></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	.</span></span></span></font></font></span></font></span></font></font></font></p>
+	assistance to </span></span></span></font></font></span></font></span><a href="mailto:SPapp_info@sil.org"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">SPapp_info@sil.org</span></span></u></span></font></font></span></font></span></a><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+	</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span><font color="#000000">
+	</font>
+	</p>
 </ul>
-<p align="left" style="line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
+<p align="left" style="line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
 <br/>
 <br/>
 

--- a/app/src/main/assets/community_work.html
+++ b/app/src/main/assets/community_work.html
@@ -3,122 +3,148 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:09:50.564000000"/>
+	<meta name="changed" content="2021-12-16T20:36:58.857000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		h3 { margin-top: 0.1in; margin-bottom: 0.08in; line-height: 100%; background: transparent; page-break-after: avoid }
-		h3.western { font-family: "Liberation Serif", serif; font-size: 14pt; font-weight: bold }
-		h3.cjk { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
-		h3.ctl { font-family: "Liberation Serif"; font-size: 14pt }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent; page-break-before: always">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Community
-Work</span></b></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Several
-language speakers who do not know the story </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">and
-who were not involved with the translation drafting will (hold and) view the
-phone and do the community check and activities. &nbsp;</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the Community Work phase is to check that the story
-translation draft is very </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">meaningful
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">and
-expressed in the language in a way that is </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">natural
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">and
-</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">clear</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span></font></font></font>
+<body lang="en-US" dir="ltr"><p align="left" style="font-variant: normal; font-style: normal; line-height: 115%; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always">
+<font color="#000000"><font face="Arial"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Community
+Work</span></b></font></font></font></p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Several
+language speakers who do not know the story </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">and
+who were not involved with the translation drafting will (hold and)
+view the phone and do the community check and activities. &nbsp;</span></span></font></font></span></font></span></p>
+<p><br/>
+<br/>
+
 </p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Listen
-	to the local language translation. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">For
-	each slide, tap the play button in the middle of the screen. Then
-	swipe to the next slide, tap play and listen. Listen to the entire
-	story slide by slide. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Suggest
-	improvements. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Listen
-	again to the story slide by slide and tell the translator who </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">is</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	nearby if you hear anything that does not sound quite right. Suggest
-	how to make that part of the story sound better. If the translator
-	is not nearby, </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">record
-	audio comments for each slide by tapping the mic button on the
-	bottom of the screen. Tap the square to stop the audio recording.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Suggest
-	improvements for things </span></b></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>such
-	as</b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Different
-		words used for the same item (inconsistency)</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Words
-		used that are from another language (borrowing foreign terms)</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Order
-		of words or phrases that sound weird or foreign (bad grammar)</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Something
-		said in a way that could have two different meanings (ambiguity)</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">&ldquo;</span></span></font></span><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Stiff&rdquo;
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+&nbsp;The purpose of the Community Work phase is to check that the
+story translation draft is very </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">meaningful
+</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">and
+expressed in the language in a way that is </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">natural
+</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">and
+</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">clear</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">.</span></span></font></font></span></font></span></p>
+<p><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+&nbsp;</span></span></font></font></span></font></span></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Listen
+	to the local language translation. &nbsp;</span></b><span style="background: transparent">For
+	each slide, tap the play button in the middle of the screen.&nbsp;
+	Then swipe to the next slide, tap play and listen.&nbsp; Listen to
+	the entire story slide by slide. &nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Suggest
+	improvements.&nbsp; </span></b><span style="background: transparent">Listen
+	again to the story slide by slide and tell the translator who is
+	nearby if you hear anything that does not sound quite right.
+	&nbsp;Suggest how to make that part of the story sound better. If
+	the translator is not nearby, record audio comments for each slide
+	by tapping the mic button on the bottom of the screen.&nbsp; Tap the
+	square to stop the audio recording.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Suggest
+	improvements for things such as</span></b><span style="background: transparent">:</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Different
+		words used for the same item (inconsistency)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Words
+		used that are from another language (borrowing foreign terms)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Order
+		of words or phrases that sound weird or foreign (bad grammar)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Something
+		said in a way that could have two different meanings (ambiguity)</span></font></font></font></p>
+		<li><p style="font-variant: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><span style="background: transparent">&ldquo;</span><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Stiff&rdquo;
 		or very literal, formal or old language that could be said more
-		naturally with an idiom (unnaturalness)</span></span></span></font></font></span></font></span></font></font></font></p>
-	</ul>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span></font></font></font>
+		naturally with an idiom (unnaturalness)</span></span></span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Customize
+	the title slide.</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Snap
+		a photo of a design or color, landscape or view to insert as the
+		background.&nbsp; Or insert a picture from the story (browse the
+		template files to find an appropriate one).</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Think
+		of a clever title that will attract people to want to listen to
+		this story. &nbsp;Type the title words in your language. Re-record
+		the title to match the text.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Add
+	a song to the end of the story.</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Discuss
+		the content and meaning of the story. &nbsp;Compose a song that
+		will help you and others remember the message for this story.
+		&nbsp;Record your song.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Snap
+		a photo of the singers or a picture to view while listening to the
+		song.</span></font></font></font></p>
+	</ol>
+</ol>
+<p style="margin-left: 0.04in"><br/>
+<br/>
+
 </p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></font></span></p>
 <ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	This work space for the Community intentionally does not include the source text for each slide.  The community or peer review should focus not on translating, but rather on evaluating and editing the provided translation to be natural and clear in the language.
-	</span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
-	can record as many comments as </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">necessary
-	for each slide</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.
-	If you want to </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">inform
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">the
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">accuracy
-	checker / consultant </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">about
-	an issue, record it in a language </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">s/he
-	speaks</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">This
+	work space for the Community intentionally does not include the
+	source text for each slide.&nbsp; The community or peer review
+	should focus not on translating, but rather on evaluating and
+	editing the provided translation to be natural and clear in the
+	language.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
+	can record as many comments as necessary for each slide. &nbsp;If
+	you want to inform the accuracy checker / consultant about an issue,
+	record it in a language s/he speaks.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
 	more than four comments are recorded, you will need to scroll down
-	the screen to access them. To scroll within the phase without
+	the screen to access them. &nbsp;To scroll within the phase without
 	swiping to another phase, press and scroll (move your finger up or
-	down) or scroll while pressing your finger. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
+	down) or scroll while pressing your finger.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
 	can rename a comment by pressing on the &ldquo;comment name&rdquo;
-	to bring up the phone keyboard. Type a new name. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Play
-	or delete any comment as desired. You can delete a comment once the
-	issue has been resolved or if it was recorded by accident.</span></span></span></font></font></span></font></span></font></font></font></p>
+	to bring up the phone keyboard. &nbsp;Type a new name.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Play
+	or delete any comment as desired. &nbsp;You can delete a comment
+	once the issue has been resolved or if it was recorded by accident.</span></font></font></font></p>
 </ul>
-<h3 class="western" align="left" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
+<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
 <br/>
 <br/>
 
-</h3>
+</p>
 </body>
 </html>

--- a/app/src/main/assets/finalize.html
+++ b/app/src/main/assets/finalize.html
@@ -1,122 +1,163 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.1.2 (Linux)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-04-04T14:35:47.051225641"/>
+	<meta name="changed" content="2022-01-19T15:18:24.776000000"/>
 	<style type="text/css">
 		@page { margin: 0.79in }
 		p { margin-bottom: 0.1in; background: transparent }
-		h3 { margin-top: 0.1in; margin-bottom: 0.08in; background: transparent; line-height: 100% }
+		h3 { line-height: 100%; margin-top: 0.1in; margin-bottom: 0.08in; background: transparent }
 		h3.western { font-family: "Liberation Serif", serif }
 		h3.cjk { font-family: "Liberation Serif" }
 		h3.ctl { font-family: "Liberation Serif" }
 	</style>
 </head>
-<body lang="en-US" dir="ltr"><h3 class="western" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-before: always">
+<body lang="en-US" dir="ltr"><h3 class="western" style="line-height: 138%; margin-top: 0.22in; margin-bottom: 0.06in; page-break-before: always">
 <font color="#000000"><font face="Arial, serif">Finalize</font></font></h3>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">primary
-translator</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">or
-phone </span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">manager
-</font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">along
-with anybody else interested in video production.</span></span></span></font></font></span></span></font></font></font></p>
+<p align="left" style="font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent; page-break-before: auto; page-break-after: auto"><a name="docs-internal-guid-9bfd660f-7fff-243f-e0bb-193f5fe927a8"></a>
+<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><span style="font-style: normal"><span style="background: transparent">:
+The </span></span></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><span style="font-style: normal"><b><span style="background: transparent">primary
+translator</span></b></span></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><span style="font-style: normal"><span style="background: transparent">or
+phone manager along with anybody else interested in video production.</span></span></font></span></span></font></font></font></p>
+<p><br/>
+<br/>
 
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the Finalize phase is to insert names to </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">
-	complete the local credits slide,
- make final decisions about the new videos that will be created, and to create videos</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	for the various audiences with whom you will share the videos. </span></span></span></font></font></span></span>
-</font></font></font>
 </p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></span></font></font></font>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+The purpose of the Finalize phase is to insert names to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">complete
+the local credits</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">slide,</span></span></font></font></span></span></font></p>
+<p style="line-height: 165%; margin-bottom: 0in"><font color="#000000"><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">&nbsp;</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">make
+final decisions</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">about
+the new videos that will be created, and to </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">create
+videos</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">for
+the various audiences with whom you will share the videos.&nbsp;</span></span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
 </p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-		Complete the Local Credits slide.
-	</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-		Tap the EDIT LOCAL CREDITS button to open an editable pop-up window.  Type in the names of people who were involved in the various activities of translation, song composition, photography, voice acting, etc. Add a phone or email for people to contact if they want to get more videos or if they have questions about the story.
-	</span></span></span></font></font></span></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-			Type a short story name
-		</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-			(in your local language) on the appropriate line.  This will appear as part of the file name of the video to assist you in identifying the content of the video. (The number of the story will be automatically added to the video file name.)  This title text can be changed whenever you want.  The grey tick/check mark in the circle will turn green when you have entered text on this line.
-	</span></span></span></font></font></span></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-			Choose options for including in the video.
-		</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-			Tap the square box for each option to make it active.  Tap it again to not include that option in the video you will create.
-	</span></span></span></font></font></span></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-			Create your new video.
-		</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-			Tap the CREATE VIDEO button and wait for the phone app to generate the new videos.  Do not do other activities on the phone while the video is being created. This will take 3 to 30 minutes depending on how long the story and song are.  You can watch the progress bar to see progress.  The app will automatically and simultaneously create your story into two types of video formats: mp4 and 3gp.
-	</span></span></span></font></font></span></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-			Recreate your video.
-		</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-			You have the ability to create several versions of your story video.  Select different options or features to produce multiple versions of your story.
-		</span></span></span></font></font></span></span></font></font></font>
-	</p>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; font-variant: normal; font-style: normal; font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent">Some
-	feature options are mutually exclusive, such as picture movement and
-	including text, so the software will not always allow you to include
-	some features.</span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; font-variant: normal; font-style: normal; font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
-	low resolution (3gp) video will take up less space (it will be smaller),
-	but it will be very “grainy” or “pixelated” on a smartphone or computer screen.</span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; font-variant: normal; font-style: normal; font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
-	higher resolution (mp4) video is necessary to be able to read slide text
-	captions / transcriptions on the screen.</span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">There
-	are several audio-visual creation options: </font></font></font>
-	</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Complete
+	the Local Credits slide.</span></b><span style="background: transparent">
+	Tap the </span><font size="2" style="font-size: 10pt"><span style="background: transparent">EDIT
+	LOCAL CREDITS</span></font><span style="background: transparent">
+	button to open an editable pop-up window.&nbsp; Type in the names of
+	people who were involved in the various activities of translation,
+	song composition, photography, voice acting, etc. Add a phone or
+	email for people to contact if they want to get more videos or if
+	they have questions about the story. Tap </span><font size="2" style="font-size: 10pt"><span style="background: transparent">SAVE
+	</span></font><span style="background: transparent">to close the
+	window and return to Finalize.&nbsp; The grey tick/check mark in the
+	circle will turn green when the local credits slide has been edited.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Type
+	a short story name</span></b><span style="background: transparent">
+	(in your local language) on the appropriate line.&nbsp; This will
+	appear as part of the file name of the video to assist you in
+	identifying the content of the video.. &nbsp;(The number of the
+	story will be automatically added to the video file name.)&nbsp;
+	This text can be changed whenever you want.&nbsp; The grey
+	tick/check mark in the circle will turn green when you have entered
+	text on this line.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Choose
+	options for including in the video.&nbsp; </span></b><span style="background: transparent">Tap
+	the square box for each option to make it active.&nbsp; Tap it again
+	to not include that option in the video you will create.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Create
+	your new video</span></b><span style="background: transparent">.
+	&nbsp;Tap the </span><font size="2" style="font-size: 10pt"><span style="background: transparent">CREATE
+	VIDEO</span></font><span style="background: transparent"> button and
+	wait for the phone app to generate the new videos.&nbsp; Do not do
+	other activities on the phone while the video is being created. This
+	will take 3 to 30 minutes depending on how long the story and song
+	are.&nbsp; You can watch the progress bar to see progress.&nbsp; The
+	app will automatically and simultaneously create your story into two
+	types of video formats: mp4 and 3gp.&nbsp;</span></font></font></font></p>
 	<ul>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Movie
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+		3gp format is a low resolution video created to play on the tiny
+		screens of feature phones.&nbsp; These videos are relatively small
+		and do not take up too much storage space -- averaging about 20 MBs
+		per story video.)&nbsp;&nbsp;</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+		mp4 format is a higher resolution video created to be viewed on
+		larger screens and also projected.&nbsp; These videos are larger
+		and each require an average of 200 MBs for storage.</span></font></font></font></p>
+	</ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Recreate
+	your video</span></b><span style="background: transparent">.&nbsp;
+	You have the ability to create several versions of your story video.
+	&nbsp;Select different options or features to produce multiple
+	versions of your story.</span></font></font></font></p>
+</ol>
+<p style="margin-left: 0.04in"><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	file name for each video will be auto-generated by the app:&nbsp; a
+	3-digit number taken from the number of the story template + a short
+	story name in the language typed by the user in the Finalize phase +
+	a 3-letter ethnologue code for the language taken from the
+	registration language information + various short 2-letter codes
+	indicating what options or features are in the video (Fx =
+	background music and effects; Sg = local song; Px = pictures; Mv =
+	movement on the pictures; Tx = story text / subtitles)</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
+	low resolution (3gp) video will take up less space (it will be
+	smaller), but it will be very &ldquo;grainy&rdquo; or &ldquo;pixelated&rdquo;
+	on a smartphone screen.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
+	higher resolution (mp4) video is necessary to be able to read text
+	captions / transcriptions on the screen.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">There
+	are several audio-visual creation options:&nbsp;&nbsp;</span></font></font></font></p>
+	<ul>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Movie
 		- animated slides with audio narration (with or without background
-		music)</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Talking
+		music)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Talking
 		Book - still slides with audio narration and text
-		captions/transcriptions (with or without background music)</font></font></font></p>
-		<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent">Book
+		captions/transcriptions (with or without background music)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Book
 		- still slides with text captions (with or without background
 		music) and auto page turns</span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Radio
-		- audio narration with background music but no visuals</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">All
-		of the above with or without an appended local song</font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Radio
+		- audio narration with background music but no visuals</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">All
+		of the above with or without an appended local song</span></font></font></font></p>
 	</ul>
 </ul>
+<p align="left" style="line-height: 138%; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent">
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/assets/learn.html
+++ b/app/src/main/assets/learn.html
@@ -3,122 +3,120 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:06:54.485000000"/>
+	<meta name="changed" content="2022-01-11T16:40:17.709000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent; page-break-before: always">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#434343"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Learn</span></b></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">One
-to three translators </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">will
+<body lang="en-US" dir="ltr"><p align="left" style="font-variant: normal; font-style: normal; line-height: 115%; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always">
+<font color="#000000"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Learn</span></b></font></font></font></p>
+<p align="left" style="font-weight: normal; line-height: 115%; orphans: 2; widows: 2; background: transparent"><a name="docs-internal-guid-ee37e459-7fff-4b22-1e64-0532ae63ac7d"></a>
+<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">One
+to three translators </span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">will
 control or hold the phone and do the work for this phase. &nbsp;At
-least one of the translators needs to know the </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">source
-</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">language.
-This same translator(s) will also do the TRANSLATE phase and be
-available for any revision work recommended from </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">those
-who do</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-the COMMUNITY and ACCURACY CHECK phases. </span></span></span></font></font></span></font></span></font></font></font>
+least one of the translators needs to know the source language. This
+same translator(s) will also do the TRANSLATE </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">+
+REVISE</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">
+phase and be available for any revision work recommended from those
+who do the COMMUNITY </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">WORK</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">
+and ACCURACY CHECK phases.&nbsp;</span></span></font></font></span></span></font></font></font></p>
+<p><br/>
+<br/>
+
 </p>
-<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the LEARN phase is to learn well and </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">integrate
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">the
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+The purpose of the LEARN phase is to learn well and </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">integrate
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">the
 story into your mind and begin thinking about how to tell the major
-</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">points</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-of the story in your language. &nbsp;Part of learning the story well (to integrate it) is to </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">record
-the story</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font size="3" style="font-size: 12pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-</span></span></span></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">all
-in one go in </span></b></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>the
-local language</b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.
+points of the story in your language. &nbsp;Part of learning the
+story well (to integrate it) is to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">record
+the story</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">all
+in one go in the local language</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">.
 &nbsp;A summary of the story is fine. You do not need to remember all
 the details. &nbsp;Hopefully you will capture some natural discourse
-markers or story connectors.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Play
-	the story </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">as
-	many times as necessary to get it into your mind.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Practise
-	retelling the story </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">in
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	local </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">language
-	several times. (You do not need to tell all the details, but try to
-	tell a good summary -- the main points -- of the story.)</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Tap
-	the mic button and record</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	yourself(s) retelling the story in </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	local </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">language.
-	&nbsp;If watching the pictures is helpful, let them roll by on their
-	own time (they are not connected timewise to your recording). &nbsp;If
-	the pictures are distracting to you while you retell and record,
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">ignore
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">the
-	pictures.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Stop
-	your recording </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">by
-	tapping the </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">square
-	button.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Listen</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
-	the triangle </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">p</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">layback
-	button to listen to your story summary. &nbsp;If you want to record
-	the whole story again, tap the mic button and say &ldquo;yes&rdquo;
-	to overwrite / delete your first recording. Then proceed to retell
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">story.
-	Tap </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">s</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">top
-	when you are finished.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Swipe
-	down to the TRANSLATE phase </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">or
-	use the drop down menu on the top of the screen to tap to the
-	TRANSLATE phase. </font></font></font></font></font>
-	</p>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 100%; orphans: 2; widows: 2">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span></font></font></font>
+markers or story connectors.</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
 </p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Play
+	the story </span></b><span style="background: transparent">as many
+	times as necessary to get it into your mind.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Practise
+	retelling the story </span></b><span style="background: transparent">in
+	the local language several times. (You do not need to tell all the
+	details, but try to tell a good summary -- the main points -- of the
+	story.)</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Tap
+	the mic button and record</span></b><span style="background: transparent">
+	yourself(s) retelling the story in the local language. &nbsp;If
+	watching the pictures is helpful, let them roll by on their own time
+	(they are not connected timewise to your recording). &nbsp;If the
+	pictures are distracting to you while you retell and record, ignore
+	the pictures.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Stop
+	your recording </span></b><span style="background: transparent">by
+	tapping the square button.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Listen</span></b><span style="background: transparent">.&nbsp;
+	Tap the triangle playback button to listen to your story summary.
+	&nbsp;If you want to record the whole story again, tap the mic
+	button and say &ldquo;yes&rdquo; to overwrite / delete your first
+	recording. Then proceed to retell the story. Tap stop when you are
+	finished.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Swipe
+	down to the TRANSLATE </span></b><b><span style="background: transparent">+
+	REVISE </span></b><b><span style="background: transparent">phase </span></b><span style="background: transparent">or
+	use the drop down menu on the top of the screen to tap to the
+	TRANSLATE </span><span style="background: transparent">+ REVISE</span><span style="background: transparent">
+	phase.&nbsp;</span></font></font></font></p>
+</ol>
+<p style="margin-left: 0.04in"><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
 <ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">This
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">This
 	recording is a pre-translation activity, or preparing you to
-	translate. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Only
-	one recording (</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	last one) will be saved. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
-	will not be allowed to pause this recording. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
+	translate.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Only
+	one recording (the last one) will be saved.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
+	will not be allowed to pause this recording.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
 	audio recording is saved separate from the progression of the
-	pictures. It is ok if </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	local </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">story
-	recording does not match/coordinate with the images/pictures.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#434343"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Mute
-	or reduce </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">the
-	volume on your phone if you want to only watch the pictures as you
-	practise retelling the story.</span></span></span></font></font></span></font></span></font></font></font></p>
+	pictures. &nbsp;It is ok if the local story recording does not
+	match/coordinate with the images/pictures.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Mute
+	or reduce the volume on your phone if you want to only watch the
+	pictures as you practise retelling the story.</span></font></font></font></p>
 </ul>
+<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
+<br/>
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/assets/registration.html
+++ b/app/src/main/assets/registration.html
@@ -1,59 +1,226 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
+	<meta name="created" content="00:00:00"/>
+	<meta name="changed" content="2022-01-11T15:49:56.677000000"/>
+	<meta name="created" content="00:00:00">
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US">
-	<h3>Registration Instructions</h3>
-	<p><strong><u>What</u></strong><strong>: </strong>There are five &ldquo;drawers&rdquo; (sections) of the Registration. Tap to open (expand) or tap to close each drawer.&nbsp;It is preferable to use English (Roman letters) when filling each field, or English alongside your local script.&nbsp;Inside each drawer, tap on the line of each field to place the cursor there and to bring up the keyboard for inserting the appropriate information.</p>
-	<p><strong><u>Who</u></strong>:The SP app trainer should guide the primary translator(s) and accuracy checker in filling out the Registration information. Most of this process is self-explanatory, but a few things will be clarified here.</p>
-	<p><strong><u>Purpose</u></strong>: The purpose of filling and submitting this Registration information is (a) to provide a record of contacts and device information about the local language story production team for those involved; (b) to provide some brief analytics to the SP app development team; (c) to make the Registration screen &ldquo;hide&rdquo; so that it does not appear each time the app is opened;</p>
-	<p><strong><u>Notes</u></strong>:</p>
+<body lang="en-US" dir="ltr"><p style="font-variant: normal; font-style: normal; font-weight: normal; text-decoration: none">
+<font color="#000000"><span style="background: transparent"><font face="Liberation Serif"><font size="2" style="font-size: 11pt"><font face="Arial"><b>General</span></b></font><font face="Arial"><span style="background: transparent">:&nbsp;</span></font></font></font></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	Registration screen is generally a one-off activity that is done
+	during the first part of a training workshop or when a local team
+	first begins to use the Story Producer (SP) app.&nbsp;&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+	each information &ldquo;drawer&rdquo; to expand it and type in the
+	information.&nbsp; Scroll down to access each field.&nbsp; Tap on a
+	line to place the cursor and bring up the keyboard ready to type
+	information.&nbsp; A few fields are drop down menus which you need
+	to tap on and choose an item. Tap the &ldquo;drawer&rdquo; again to
+	close it.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	you </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">SKIP
+	REGISTRATION</span></b></font><span style="background: transparent">,
+	you can go directly to the Story Templates list.&nbsp; The next time
+	you open the Story Producer app, the Registration screen will
+	appear.&nbsp; If you </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">SUBMIT
+	</span></b></font><span style="background: transparent">the
+	Registration, the Registration screen will be hidden and not appear
+	each time you open the app.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	the Registration information needs to be edited and (re)submitted,
+	it can be accessed by tapping on the top left 3-bar menu icon in any
+	screen which will open a </span><b><span style="background: transparent">sidebar
+	menu</span></b><span style="background: transparent">.&nbsp; Tap on
+	</span><b><span style="background: transparent">Update Registration</span></b><span style="background: transparent">.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Filling
+	all the fields and submitting the Registration is not a requirement
+	to use the app, but it is helpful to submit the Registration
+	information to assist with future analytics and troubleshooting.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">It
+	is suggested that the local SP team leader input the information
+	requested with the help of the SP Trainer.&nbsp; Contact information
+	will need to be provided for the primary translators, the Accuracy
+	checker and the Trainer.&nbsp; The Trainer should be prepared with
+	language information readily available.</span></font></font></font></p>
+	<li><p style="line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent">
+	<span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
+	SP Trainer is ultimately responsible for submitting the Registration
+	info via email to </span></span></span></font></font></span></font></span><a href="mailto:SPapp_info@sil.org"><span style="font-variant: normal"><font color="#1155cc"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">SPapp_info@sil.org</span></span></u></span></font></font></span></font></span></a><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.
+	When </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">submitting
+	via email</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">,
+	all other emails listed in the Registration fields will
+	automatically be inserted into the email addressee section.</span></span></span></font></font></span></font></span></p>
+</ol>
+<ul>
 	<ul>
-		<li>It is not required to submit the registration information to be able to use the Story Producer app (SP app), but submitting registration information helps the Story Producer team to support you as the user.</li>
-		<li>Data that is typed into any Registration drawer or section will be saved automatically.</li>
-		<li>If the user taps <strong>SKIP REGISTRATION</strong>, the app will navigate to the Story Templates list.</li>
-		<li>To access the Registration screen from anywhere else in the app, tap the <strong>3-line</strong> main menu icon (top left corner of the screen) and tap &ldquo;<strong>Update Registration</strong>&rdquo;</li>
+		<li><p style="line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent">
+		<span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
+		a local SP team phone does not have internet connectivity, the
+		Registration info (a small text doc) can be submitted via bluetooth
+		to the Trainer&rsquo;s phone.&nbsp; Then when the Trainer gets
+		online, they can resubmit or forward the Registration info on to
+		</span></span></span></font></font></span></font></span><a href="mailto:SPapp_info@sil.org"><span style="font-variant: normal"><font color="#1155cc"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">SPapp_info@sil.org</span></span></u></span></font></font></span></font></span></a><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.&nbsp;</span></span></span></font></font></span></font></span></p>
 	</ul>
-	<p><strong><u>Language Information</u></strong></p>
-	<ol>
-		<li>To find the 3-letter <strong>Ethnologue Code</strong> for your local language, tap the <strong>WHAT IS THIS?</strong> button to browse the online ethnologue website.&nbsp; SP Trainers should research this info before any local offline training. If your local language or dialect is not listed on the website, type in the 3-letter code of the most closely related language that is listed, then add a dash (-) followed directly by the first three letters of your local dialect name (e.g. pex-maj). If this field is filled out, the language code will be automatically included in each file name of all the videos created.&nbsp; (When the SP phone is online, Story Producer will automatically send the filename for each new created video to the SP developers&rsquo; nonpublic, secure database and thereby supply simple analytics about what languages and dialects are producing which story videos.)</li>
-		<li>To the right of the <strong>Orthography Status</strong> field, there is a small drop-down menu arrow.&nbsp; Tap the arrow and then tap the best choice to describe the status of your local orthography (that is, your language writing system or alphabet).&nbsp;</li>
-	</ol>
-	<p><strong><u>Translator Information</u></strong></p>
-	<ol>
-		<li>If you want to provide information for more than one translator, simply put a comma after a name and put another name or phone contact, etc. (It is best if the translators for the SP team are located logistically close to each other so that it is not a burden to get together for story production.)</li>
-		<li>Translator <strong>Communication Preference</strong> can be indicated by tapping the small drop-down menu arrow and then tapping the preferred option.</li>
-	</ol>
-	<p><strong><u>Accuracy Checker Info</u></strong></p>
-	<ol>
-		<li>This drawer is for typing in the information about the one who is qualified and has been chosen to be the &ldquo;consultant&rdquo; or accuracy checker to approve the translation drafts.&nbsp; This person should have some good training and experience as a Bible translator and be familiar with the consultant checking process, with key terms, and perhaps have access to exegetical helps. The SP Trainer is responsible for connecting a qualified Accuracy Checker to each local language team they train.&nbsp;</li>
-		<li>Accuracy Checker<strong> Communication Preference</strong> can be indicated by tapping the small drop-down menu arrow and then tapping the preferred option.</li>
-		<li>It is important to be aware about the <strong>Location Type</strong> drop-down menu!!&nbsp; Most Accuracy Checkers will be <strong>local</strong>.&nbsp; This means that they will be physically on-site or &ldquo;on-sight&rdquo; electronically to view and control the phone and the process during the Accuracy Check phase until the approval passcode is submitted and the last phases of video production are unlocked.&nbsp; When the location type is <strong>local</strong>, the interface of the SP app will have one offline checking phase for each story.&nbsp; If the <strong>remote</strong> location type is chosen, this will <u>trigger</u> the interface of the SP app to change &ndash; the accuracy checking will involve three <u>online</u> interface phases and the approval will be controlled <u>remotely</u> via the ROCC web app.&nbsp; This remote option is not yet available and cannot be utilized.</li>
-	</ol>
-	<p><strong><u>Trainer Information</u></strong></p>
-	<ol>
-		<li>This is self-explanatory.&nbsp; Even if the trainer is the same person as the Accuracy Checker, it is helpful to submit this info.</li>
-		<li><strong>Location</strong>.&nbsp; This should be the normal place where the Trainer is located long term (not where the training is done).</li>
-	</ol>
-	<p><strong><u>Archive Information</u></strong></p>
-	<ol>
-		<li>You may or may not have an(other) email contact to place here. If an email is typed in here, and the Registration info is submitted via email, this contact will automatically be placed in the recipient field of the email.&nbsp;&nbsp; Some organization entities may have a contact to which they would like to have all created videos be sent (to keep local records of published materials).&nbsp; Put that contact here and also help the primary translator-story producer to find a way to send a copy of their videos to this contact. (That might be via uploading to a drop box or side-loading to a flash drive etc.)</li>
-	</ol>
-	<p><strong><u>SUBMIT VIA&hellip;</u></strong></p>
+</ul>
+<p style="font-variant: normal; font-style: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Language
+Information:</span></b></font></font></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">The
+	Ethnologue Code</span></b><span style="background: transparent"> is
+	a 3-letter code which has been assigned to each language.&nbsp; Tap
+	on the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">WHAT
+	IS THIS?</span></b></font><span style="background: transparent">
+	link to access the online Ethnologue database to search for a
+	specific code. If you are working in a language or dialect that has
+	not yet been assigned a code, please type the 3-letter code of the
+	most closely related language followed by a dash (no spaces)
+	followed immediately by 3 primary letters of the dialect name.&nbsp;
+	For example, PEX-MAJ. This code, if inserted and submitted, will
+	appear in the partially automated title of all videos produced so
+	that it is clear with which language the video is produced.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0.06in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Orthography
+	Status</span></b><span style="background: transparent"> has to do
+	with the newness and stability of the language writing system or
+	alphabet.&nbsp; Tap on the drop down menu and then tap on the most
+	appropriate option.</span></font></font></font></p>
+</ul>
+<p style="font-variant: normal; font-style: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Translator
+Information:</span></b></font></font></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	you wish to enter information for more than one translator, simply
+	put a comma or a slash and list the multiple people with their
+	corresponding information on the same line.</span></font></font></font></p>
+</ul>
+<p style="font-variant: normal; font-style: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Consultant
+Information:</span></b></font></font></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">This
+	drawer or section is where information is registered for the
+	Accuracy Checker.&nbsp; The </span><b><span style="background: transparent">Consultant
+	(also called the Accuracy Checker)</span></b><span style="background: transparent">
+	should not be the same person as a Translator.&nbsp; The Consultant
+	or Accuracy Checker may or may not be the same person as the
+	Trainer.&nbsp;</span></font></font></font></p>
 	<ul>
-		<li>It is ok to submit the Registration info even if some fields are blank.</li>
-		<li>Be sure to be online (or have phone connectivity) and actually <strong>send</strong> the Registration text info&nbsp;once an app has been chosen by which to submit the information.</li>
-		<li>If the SP app phone is offline, the Registration info can be submitted via Bluetooth to the Trainer&rsquo;s phone. Then when the Trainer is online, s/he can (re)submit the Registration info via email to <a href="mailto:SPapp_info@sil.org">SPapp_info@sil.org</a></li>
-		<li>It is preferable to submit the Registration info via email, but other ways are also acceptable.</li>
-		<li>Trainers should show the SP phone manager (i.e. the primary translator or local Accuracy Checker) how to update the registration information via the 3-line main menu which can be accessed from any screen.</li>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Ideally,
+		the Accuracy Checker for Bible stories should be a Translation
+		Consultant.&nbsp; Certainly an Accuracy Checker should be someone
+		with translation training and years of experience in translating
+		the Bible, involvement in checking processes, sorting out key terms
+		in a thoughtful way and access to exegetical helps.&nbsp;</span></font></font></font></p>
 	</ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">It
+	is important for the Trainer to ensure that every Story Producer
+	language project has been assigned and connected to an Accuracy
+	Checker who can assist with approving each story.&nbsp; Only the
+	Accuracy Checker is entrusted with an approval password by the
+	Trainer.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
+	Consultant (Accuracy Checker)  will be doing in-person accuracy
+	checks on each story, personally (or by proxy e.g. via Whatsapp)
+	holding the SP phone, and controlling the check and any revisions
+	required before approving the story for publication and
+	distribution.&nbsp; Usually a local Accuracy Checker speaks the
+	local language.</span></font></font></font></p>
+</ul>
+<p style="font-variant: normal; font-style: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Trainer
+Information:</span></b></font></font></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">This
+	drawer or section contains the contact information for the certified
+	SP Trainer who is helping a new Story Producer language team get set
+	up.&nbsp;&nbsp;</span></font></font></font></p>
+	<ul>
+		<li><p style="line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent">
+		<span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">People
+		get qualified to be SP Trainers by taking a course or self
+		educating (by working through the unlocked demo story available
+		from the main menu, reading all the Help docs in each phase,
+		perhaps watching some training videos) and passing the &ldquo;Qualify
+		as a SP app Trainer&rdquo; Quiz. Contact </span></span></span></font></font></span></font></span><a href="mailto:SPapp_info@sil.org"><span style="font-variant: normal"><font color="#1155cc"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">SPapp_info@sil.org</span></span></u></span></font></font></span></font></span></a><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+		</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">for
+		training options and for access to the SP Trainer Quiz.</span></span></span></font></font></span></font></span></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">SP
+		Trainers are responsible for:</span></font></font></font></p>
+		<ul>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">setting
+			up and training local language teams in use of the Story Producer
+			app</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">connecting
+			local SP teams with a local or remote Accuracy Checker&nbsp;&nbsp;</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">training
+			and mentoring other SP Trainers</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">sharing
+			the SP approval password only with Accuracy Checkers</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">submitting
+			Registration information (via email) for teams that they train</span></font></font></font></p>
+		</ul>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Usually,
+		about a week of on-site or remote training is required from a
+		certified Story Producer Trainer to get a local language team set
+		up and running competently on the SP app.&nbsp;&nbsp;</span></font></font></font></p>
+	</ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0.06in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	</span><b><span style="background: transparent">Trainer&rsquo;s
+	location</span></b><span style="background: transparent"> should be
+	the place where the Trainer normally resides most of the time.</span></font></font></font></p>
+</ul>
+<p style="font-variant: normal; font-style: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0.06in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Archive
+Information:</span></b></font></font></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-top: 0.22in; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">This
+	is where other email addresses can be typed if there is an
+	organization or interested party who wants to receive the
+	Registration information.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 120%; margin-bottom: 0.06in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	an organization or interested party would like to receive produced
+	videos, a whatsapp number or an email address could be entered here
+	to provide a way for the local SP team leader to share videos with
+	them.</span></font></font></font></p>
+</ul>
+<p><br/>
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/assets/registration.html
+++ b/app/src/main/assets/registration.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
+	<title></title>
+	<style type="text/css">
+		@page { size: 8.5in 11in; margin: 0.79in }
+		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
+		a:link { color: #000080; so-language: zxx; text-decoration: underline }
+		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+	</style>
+</head>
+<body lang="en-US">
+	<h3>Registration Instructions</h3>
+	<p><strong><u>What</u></strong><strong>: </strong>There are five &ldquo;drawers&rdquo; (sections) of the Registration. Tap to open (expand) or tap to close each drawer.&nbsp;It is preferable to use English (Roman letters) when filling each field, or English alongside your local script.&nbsp;Inside each drawer, tap on the line of each field to place the cursor there and to bring up the keyboard for inserting the appropriate information.</p>
+	<p><strong><u>Who</u></strong>:The SP app trainer should guide the primary translator(s) and accuracy checker in filling out the Registration information. Most of this process is self-explanatory, but a few things will be clarified here.</p>
+	<p><strong><u>Purpose</u></strong>: The purpose of filling and submitting this Registration information is (a) to provide a record of contacts and device information about the local language story production team for those involved; (b) to provide some brief analytics to the SP app development team; (c) to make the Registration screen &ldquo;hide&rdquo; so that it does not appear each time the app is opened;</p>
+	<p><strong><u>Notes</u></strong>:</p>
+	<ul>
+		<li>It is not required to submit the registration information to be able to use the Story Producer app (SP app), but submitting registration information helps the Story Producer team to support you as the user.</li>
+		<li>Data that is typed into any Registration drawer or section will be saved automatically.</li>
+		<li>If the user taps <strong>SKIP REGISTRATION</strong>, the app will navigate to the Story Templates list.</li>
+		<li>To access the Registration screen from anywhere else in the app, tap the <strong>3-line</strong> main menu icon (top left corner of the screen) and tap &ldquo;<strong>Update Registration</strong>&rdquo;</li>
+	</ul>
+	<p><strong><u>Language Information</u></strong></p>
+	<ol>
+		<li>To find the 3-letter <strong>Ethnologue Code</strong> for your local language, tap the <strong>WHAT IS THIS?</strong> button to browse the online ethnologue website.&nbsp; SP Trainers should research this info before any local offline training. If your local language or dialect is not listed on the website, type in the 3-letter code of the most closely related language that is listed, then add a dash (-) followed directly by the first three letters of your local dialect name (e.g. pex-maj). If this field is filled out, the language code will be automatically included in each file name of all the videos created.&nbsp; (When the SP phone is online, Story Producer will automatically send the filename for each new created video to the SP developers&rsquo; nonpublic, secure database and thereby supply simple analytics about what languages and dialects are producing which story videos.)</li>
+		<li>To the right of the <strong>Orthography Status</strong> field, there is a small drop-down menu arrow.&nbsp; Tap the arrow and then tap the best choice to describe the status of your local orthography (that is, your language writing system or alphabet).&nbsp;</li>
+	</ol>
+	<p><strong><u>Translator Information</u></strong></p>
+	<ol>
+		<li>If you want to provide information for more than one translator, simply put a comma after a name and put another name or phone contact, etc. (It is best if the translators for the SP team are located logistically close to each other so that it is not a burden to get together for story production.)</li>
+		<li>Translator <strong>Communication Preference</strong> can be indicated by tapping the small drop-down menu arrow and then tapping the preferred option.</li>
+	</ol>
+	<p><strong><u>Accuracy Checker Info</u></strong></p>
+	<ol>
+		<li>This drawer is for typing in the information about the one who is qualified and has been chosen to be the &ldquo;consultant&rdquo; or accuracy checker to approve the translation drafts.&nbsp; This person should have some good training and experience as a Bible translator and be familiar with the consultant checking process, with key terms, and perhaps have access to exegetical helps. The SP Trainer is responsible for connecting a qualified Accuracy Checker to each local language team they train.&nbsp;</li>
+		<li>Accuracy Checker<strong> Communication Preference</strong> can be indicated by tapping the small drop-down menu arrow and then tapping the preferred option.</li>
+		<li>It is important to be aware about the <strong>Location Type</strong> drop-down menu!!&nbsp; Most Accuracy Checkers will be <strong>local</strong>.&nbsp; This means that they will be physically on-site or &ldquo;on-sight&rdquo; electronically to view and control the phone and the process during the Accuracy Check phase until the approval passcode is submitted and the last phases of video production are unlocked.&nbsp; When the location type is <strong>local</strong>, the interface of the SP app will have one offline checking phase for each story.&nbsp; If the <strong>remote</strong> location type is chosen, this will <u>trigger</u> the interface of the SP app to change &ndash; the accuracy checking will involve three <u>online</u> interface phases and the approval will be controlled <u>remotely</u> via the ROCC web app.&nbsp; This remote option is not yet available and cannot be utilized.</li>
+	</ol>
+	<p><strong><u>Trainer Information</u></strong></p>
+	<ol>
+		<li>This is self-explanatory.&nbsp; Even if the trainer is the same person as the Accuracy Checker, it is helpful to submit this info.</li>
+		<li><strong>Location</strong>.&nbsp; This should be the normal place where the Trainer is located long term (not where the training is done).</li>
+	</ol>
+	<p><strong><u>Archive Information</u></strong></p>
+	<ol>
+		<li>You may or may not have an(other) email contact to place here. If an email is typed in here, and the Registration info is submitted via email, this contact will automatically be placed in the recipient field of the email.&nbsp;&nbsp; Some organization entities may have a contact to which they would like to have all created videos be sent (to keep local records of published materials).&nbsp; Put that contact here and also help the primary translator-story producer to find a way to send a copy of their videos to this contact. (That might be via uploading to a drop box or side-loading to a flash drive etc.)</li>
+	</ol>
+	<p><strong><u>SUBMIT VIA&hellip;</u></strong></p>
+	<ul>
+		<li>It is ok to submit the Registration info even if some fields are blank.</li>
+		<li>Be sure to be online (or have phone connectivity) and actually <strong>send</strong> the Registration text info&nbsp;once an app has been chosen by which to submit the information.</li>
+		<li>If the SP app phone is offline, the Registration info can be submitted via Bluetooth to the Trainer&rsquo;s phone. Then when the Trainer is online, s/he can (re)submit the Registration info via email to <a href="mailto:SPapp_info@sil.org">SPapp_info@sil.org</a></li>
+		<li>It is preferable to submit the Registration info via email, but other ways are also acceptable.</li>
+		<li>Trainers should show the SP phone manager (i.e. the primary translator or local Accuracy Checker) how to update the registration information via the 3-line main menu which can be accessed from any screen.</li>
+	</ul>
+</body>
+</html>

--- a/app/src/main/assets/share.html
+++ b/app/src/main/assets/share.html
@@ -1,192 +1,207 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.1.2 (Linux)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-04-02T16:58:01.141362206"/>
+	<meta name="changed" content="2022-01-11T16:57:06.894000000"/>
 	<style type="text/css">
 		@page { margin: 0.79in }
 		p { margin-bottom: 0.1in; background: transparent }
-		h3 { margin-top: 0.1in; margin-bottom: 0.08in; background: transparent; line-height: 100% }
+		h3 { line-height: 100%; margin-top: 0.1in; margin-bottom: 0.08in; background: transparent }
 		h3.western { font-family: "Liberation Serif", serif }
 		h3.cjk { font-family: "Liberation Serif" }
 		h3.ctl { font-family: "Liberation Serif" }
 	</style>
 </head>
-<body lang="en-US" dir="ltr"><h3 class="western" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-before: always">
+<body lang="en-US" dir="ltr"><h3 class="western" style="line-height: 138%; margin-top: 0.22in; margin-bottom: 0.06in; page-break-before: always">
 <font color="#000000"><font face="Arial, serif">Share</font></font></h3>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">primary
-translator</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">or
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto"><a name="docs-internal-guid-42c24eea-7fff-6973-3b63-acb106c63d55"></a>
+<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent"><font face="Arial"><u><b>Who</b></u></font><font face="Arial">:
+The </font><font face="Arial"><b>primary translator</b></font> <font face="Arial">or
 phone owner along with anybody else interested in distributing the
-videos.</span></span></span></font></font></span></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the Share phase is to </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">view
-</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">and
-</span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">distribute
-</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">the
-videos to others in your language community, whether they are nearby
-or far away, whether </span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">via
-offline or online means</font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></span></font></font></font>
+videos.</font></span></font></font></font></p>
+<p><br/>
+<br/>
+
 </p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>View
-	a created video. </b></font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+The purpose of the Share phase is to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">view
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">and
+</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">distribute
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">the
+videos to others in your language community, whether they are nearby
+or far away, whether via offline or online means.</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">View
+	a created video. </span></b><span style="background: transparent">Tap
 	the triangle play button on the line with a video file name to view
-	that video. You will need to select a video player or photo viewer on your phone.</span></span></span></font></font></span></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Constructive
-	review.</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">View
-	a video </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">all</span></span></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-	</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">the</span></span></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-	</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">way</span></span></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-	</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">through</span></span></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-	</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">before
-	you share it to make sure that it looks and sounds the way it is
-	supposed to. </span></span></span></font></font></span></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Revise
-	faulty videos. </b></font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
-	a video has mistakes in it, delete both the mp4 and 3gp for that video by tapping on the trash bin X icon to the right of the file you want to delete. &nbsp;Make revisions
-	in the </span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">VOICE
-	STUDIO </font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">and
-	</span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">FINALIZE
-	</font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">phases,
-	and create a new video.</span></span></span></font></font></span></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Share it.
-	</b></font></font> <span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-		Distribute 3gp (low resolution) videos to cell phones with tiny screens. Distribute mp4 (high resolution) videos to devices with larger screens, for example smartphones, tablets and computers. Tap
-	the 3-point open triangle share button to distribute it. You</span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">r</span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	phone will bring up several offline and online options for sharing:</span></span></span></font></font></span></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Bluetooth</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-		</font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Connecting
-		your phone to another phone via </span></span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="background: transparent">bluetooth
-		</span></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">is
-		the safest way to share videos offline one at a time. It may take
-		10 or 20 minutes to transfer a single video via bluetooth.</span></span></span></font></font></span></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Whatsapp
-		or email attachment. </b></font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
-		you have </span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">data
-		or wifi and </font></font><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">ability
-		to connect to the internet, you can share by attachin</span></span></span></font></font></span></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">g
-		your video to Whatsapp (or a Whatsapp group) or to email (copy
-		multiple recipients). You may have to browse to find and attach the
-		video to email.</font></font></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Upload
-		or post. </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">If
-		you have strong internet connectivity, you can upload</font></font><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
-		</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">your
-		videos to Youtube or FB, google drive, dropbox or your language website, then share the link with friends. (To upload your videos to ScriptureEarth.com contact info@ScriptureEarth.org)</span></span></span></font></font></span></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>OTG
-		flash drive or SD card swapping.</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">Another
-		offline option for sharing is to utilize a file manager to put the
-		videos on a flash drive (with Android connectors) or card reader
-		and then manually put the SD card in another phone. This is the
-		least advisable way to share because the transfer of viruses is
-		likely.</font></font></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Load
-		and sell SD cards.</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">Once you have produced a significant amount of story videos (i.e. more than 30), you can go to the VIDEOS folder (tap the VIDEOS FOLDER button to view the path location), and utilizing a File Manager app or OTG device, load micro SD cards with all the low resolution videos for feature phones (for example) and then distribute/sell those SD cards to feature phone owners.
-		</font></font></font></font></font>
-		</p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Backup
-	all videos regularly</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-		It is a good idea to backup the Video directory on a regular basis when videos are regularly being created.  Backup to an OnTheGo (OTG) flash drive or to a computer hard drive or another SD card. Another way to backup videos is to upload them all to YouTube or some other place online (e.g. Google Drive; Scripture Earth).  Of course, as you distribute the videos to other devices in your community, this is also a backup system.
-	</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Use
-	the shared videos</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">in
-	various types of evangelistic, discipleship and Scripture engagement
-	activities. For example:</font></font></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Sunday
-		school classes</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Men
-		or women Bible study groups</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Family
-		devotions</font></font></font></p>
-		<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="background: transparent">preparation
+	that video.&nbsp; You will need to select a video player or photo
+	viewer on your phone.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Constructive
+	review.</span></b><span style="background: transparent">&nbsp; View
+	a video </span><u><span style="background: transparent">all</span></u><span style="background: transparent">
+	</span><u><span style="background: transparent">the</span></u><span style="background: transparent">
+	</span><u><span style="background: transparent">way</span></u><span style="background: transparent">
+	</span><u><span style="background: transparent">through</span></u><span style="background: transparent">
+	before you share it to make sure that it looks and sounds the way it
+	is supposed to.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Revise
+	faulty videos. </span></b><span style="background: transparent">&nbsp;If
+	a video has mistakes in it, delete both the mp4 and 3gp for that
+	video by tapping on the trash bin icon with the X. &nbsp;Make
+	revisions in the VOICE STUDIO and FINALIZE phases, and create a new
+	video.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Share
+	it.</span></b><span style="background: transparent">&nbsp; Tap the
+	3-point open triangle share button to distribute it. &nbsp;You phone
+	will bring up several offline and online options for sharing:</span></font></font></font></p>
+	<ol>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Bluetooth</span></b><span style="background: transparent">.&nbsp;
+		Connecting your phone to another phone via </span><u><span style="background: transparent">bluetooth
+		</span></u><span style="background: transparent">is the safest way
+		to share videos offline one at a time.&nbsp; It may take 10 or 20
+		minutes to transfer a single video via bluetooth.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Whatsapp
+		or email attachment. </span></b><span style="background: transparent">&nbsp;If
+		you have data or wifi and ability to connect to the internet, you
+		can share by attaching your video to Whatsapp (or a Whatsapp group)
+		or to email (copy multiple recipients).&nbsp; You may have to
+		browse to find and attach the video to email.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Upload
+		or post.&nbsp; </span></b><span style="background: transparent">If
+		you have strong internet connectivity, you can upload your videos
+		to Youtube or FB, google drive, dropbox or your language website,
+		then share the links with friends.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">OTG
+		flash drive or SD card swapping.</span></b><span style="background: transparent">&nbsp;
+		Another offline option for sharing is to utilize a file manager to
+		put the videos on a flash drive (with Android connectors) or card
+		reader and then manually put the SD card in another phone.&nbsp;
+		This is the least advisable way to share because the transfer of
+		viruses is likely.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Load
+		and sell SD cards.</span></b><span style="background: transparent">&nbsp;
+		Once you have produced a significant amount of story videos (i.e.
+		more than 30), you can go to the </span><font size="2" style="font-size: 10pt"><span style="background: transparent">VIDEOS
+		</span></font><span style="background: transparent">folder (tap the
+		</span><font size="2" style="font-size: 10pt"><span style="background: transparent">VIDEOS
+		FOLDER</span></font><span style="background: transparent"> button
+		to view the path location), and utilizing a File Manager app or OTG
+		device, load micro SD cards with all the low resolution videos for
+		feature phones (for example) and then distribute/sell those SD
+		cards to feature phone owners.&nbsp;&nbsp;</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Backup
+	all videos regularly</span></b><span style="background: transparent">.
+	It is a good idea to backup the Video directory on a regular basis
+	when videos are regularly being created.&nbsp; Backup to an OnTheGo
+	(OTG) flash drive or to a computer hard drive or another SD card.
+	Another way to backup videos is to upload them all to YouTube or
+	some other place online (e.g. Google Drive; Scripture Earth).&nbsp;
+	Of course, as you distribute the videos to other devices in your
+	community, this is also a backup system.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Use
+	the shared videos</span></b><span style="background: transparent">
+	in various types of evangelistic, discipleship and Scripture
+	engagement activities.&nbsp; For example:</span></font></font></font></p>
+	<ol>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Sunday
+		school classes</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Men
+		or women Bible study groups</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Family
+		devotions</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">preparation
 		for sermons</span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">private
-		viewing and learning</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">public
-		showings projected onto a larger screen</font></font></font></p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Group
-	video activities: </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">Play
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">private
+		viewing and learning</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">public
+		showings projected onto a larger screen</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Group
+	video activities: </span></b><span style="background: transparent">Play
 	the video several times for a group and then do the following
-	activities:</font></font></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Dramatize
-		and retell the story, acting it out.</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Learn
-		the song.</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Memorize
-		a key verse from the story.</font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Discuss
-		these questions:</font></font></font></p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">What
-			do you learn about God from this story?</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">What
-			do you learn about people from this story?</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">What
-			good and bad examples do you observe from this story?</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">What
-			life lessons do you learn from this story?</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-				In what way do you need to obey the Lord because you have learned from this story?
-			</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-			<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">What
+	activities:</span></font></font></font></p>
+	<ol>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Dramatize
+		and retell the story, acting it out.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Learn
+		the song.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Memorize
+		a key verse from the story.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Discuss
+		these questions:</span></font></font></font></p>
+		<ol>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">What
+			do you learn about God from this story?</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">What
+			do you learn about people from this story?</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">What
+			good and bad examples do you observe from this story?</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">What
+			life lessons do you learn from this story?</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">In
+			what way do you need to obey the Lord because you have learned
+			from this story?</span></font></font></font></p>
+			<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+			<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">What
 			other verses or teaching in the Bible support what you have
-			learned from this story?</font></font></font></p>
-		</ul>
-	</ul>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">
-	Notes</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
+			learned from this story?</span></font></font></font></p>
+		</ol>
+	</ol>
+</ol>
+<p style="margin-left: 0.03in"><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:&nbsp;</span></span></font></font></span></span></font></p>
 <ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	All the created videos are located in a Video folder/directory located in the root of the SP Templates directory. 
-	</span></span></span></font></font></span></span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">All
+	the created videos are located in a Video folder/directory located
+	in the root of the SP Workspace directory.&nbsp; </span></font></font></font>
+	</p>
 </ul>
-	</span></span></span></font></font></span></span></font></font></font></p>
+<p align="left" style="line-height: 138%; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent">
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/assets/story_list.html
+++ b/app/src/main/assets/story_list.html
@@ -3,37 +3,126 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:06:32.164000000"/>
+	<meta name="changed" content="2021-12-16T20:25:32.804000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		h3.cjk { font-family: "NSimSun" }
+		h3.ctl { font-family: "Lucida Sans" }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent; page-break-before: always">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#434343"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Story
-Templates</span></b></span></font></font></span></font></span></font></font></font></p>
+<body lang="en-US" dir="ltr"><h3 class="western" align="left" style="font-variant: normal; font-style: normal; line-height: 115%; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always">
+<font color="#434343"><font face="Arial"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Story
+Templates</span></b></font></font></font></h3>
+<p align="left" style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">General:&nbsp;</span></b></font></font></font></p>
 <ul>
-	<li><p style="margin-bottom: 0in; line-height: 100%">Tap on any
-	story template to open it and begin (or continue) your translation
-	work.</p>
-	<li><p style="margin-bottom: 0in; line-height: 100%">You can work on
-	multiple templates, but only one at a time. 
-	</p>
-	<li><p style="margin-bottom: 0in; line-height: 100%">You don&rsquo;t
+	<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+	on any story template title to open it and begin (or continue) your
+	translation work.</span></font></font></font></p>
+	<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
+	can work on multiple templates, but only one at a time. You don&rsquo;t
 	have to completely finish a story before starting work on another
-	story. (Although it is recommended that you try to complete your
-	work in a phase before exiting to work on something else.) 
-	</p>
-	<li><p style="margin-bottom: 0in; line-height: 100%">If you exit one
-	template to work on another one, your work data will be saved
-	automatically.</p>
-	<li><p style="margin-bottom: 0in; line-height: 100%">Any template
-	that you open and close, will open in the same phase (or place)
-	where you stopped before.</p>
+	story. &nbsp;(Although it is recommended that you try to complete
+	your work in a phase before exiting to work on something else.)&nbsp;</span></font></font></font></p>
+	<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	you exit one template to work on another one, your work data will be
+	saved automatically.&nbsp;</span></font></font></font></p>
+	<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Any
+	template that you open and close, will open in the same phase (or
+	place) where you stopped before.</span></font></font></font></p>
+	<li><p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">No
+	matter where you are in the app, you can always tap on the 3-lines
+	menu icon (located top left in all screens) to give you the option
+	to return to the list of Story Templates.&nbsp; (Tap on </span><b><span style="background: transparent">Story
+	Templates</span></b><span style="background: transparent">.)</span></font></font></font></p>
 </ul>
+<p align="left" style="line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent">
+<span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Progress
+tabs:</span></b></span></font></font></span></font></span></p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">At
+the top of the story list, there are three tabs:&nbsp; </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">ALL
+STORIES</span></b></font><font size="2" style="font-size: 9pt"><span style="background: transparent">,
+</span></font><font size="2" style="font-size: 9pt"><b><span style="background: transparent">IN
+PROGRESS</span></b></font><span style="background: transparent"> </span><font size="2" style="font-size: 9pt"><span style="background: transparent">and
+</span></font><font size="2" style="font-size: 9pt"><b><span style="background: transparent">COMPLETED</span></b></font><span style="background: transparent">.&nbsp;
+The tab which you are currently viewing will be bolded and indicated
+with a blue line.&nbsp; The default tab is </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">ALL
+STORIES</span></b></font><span style="background: transparent">.&nbsp;
+This tab lists all the stories which have been scanned into the SP
+app.&nbsp; To change which tab you would like to view, simply tap on
+the words labeling the tab.</span></font></font></font></p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<br/>
+
+</p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">When
+you have started to translate a story, as soon as you make the first
+audio recording in the Translate + Revise phase, this action will
+cause that story to show up in the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">IN
+PROGRESS </span></b></font><span style="background: transparent">tab.
+Also, a blue &ldquo;highlighting&rdquo; marker will appear to the
+right of the story title in the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">ALL
+STORIES </span></b></font><span style="background: transparent">tab
+list.&nbsp; So, if you are working on several stories at one time,
+rather than scrolling slowly through many story templates to find the
+stories that are in progress, you can quickly scroll and find the
+blue marker(s), or you can tap on the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">IN
+PROGRESS </span></b></font><span style="background: transparent">tab
+to find a short list of the stories that you have started but not yet
+finished.</span></font></font></font></p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<br/>
+
+</p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Once
+you produce a video for a story, the SP app will consider that you
+have completed that story and it will no longer show up in the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">IN
+PROGRESS</span></b></font><span style="background: transparent"> tab;
+it will show up in the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">COMPLETED
+</span></b></font><span style="background: transparent">tab.&nbsp;
+Also, the titles for completed stories will be dimmed in the </span><font size="2" style="font-size: 9pt"><b><span style="background: transparent">ALL
+STORIES</span></b></font><span style="background: transparent"> Story
+Template list and the blue marker will become grey.&nbsp; As an app
+user, you still have complete access to edit stories, produce
+different versions of a story video and share videos from the Share
+phase even after it is &ldquo;completed&rdquo;.&nbsp;</span></font></font></font></p>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<br/>
+
+</p>
+<p align="left" style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Filter
+feature:</span></b></font></font></font></p>
+<p align="left"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
+you have all the available story templates installed in your app, it
+can be a long list to scroll through.&nbsp; The stories can be sorted
+or filtered by tapping on the white &ldquo;buttons&rdquo; at the top
+of the story list. When a tick mark is showing on a white button, it
+means those stories are see-able or shown in the list.&nbsp; If there
+is no tick mark on a button, it means those stories are hidden.&nbsp;
+Tap the </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">OT</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="font-weight: normal"><span style="background: transparent">
+</span></span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">button
+to show or hide </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">O</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">ld
+</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">T</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">estament
+stories.&nbsp; Tap the </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">NT</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="font-weight: normal"><span style="background: transparent">
+</span></span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">button
+to show or hide </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">N</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">ew
+</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">T</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">estament
+stories. Tap the </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Othe</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">r
+button to show or hide other types of (non Bible) stories -- stories
+used for app training, evangelism and health information etc. </span></span></span></font></font></span></font></span>
+</p>
 </body>
 </html>

--- a/app/src/main/assets/translate_revise.html
+++ b/app/src/main/assets/translate_revise.html
@@ -3,189 +3,194 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:20:52.622000000"/>
+	<meta name="changed" content="2022-01-19T15:12:26.929000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; background: transparent; line-height: 115%; background: transparent }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="margin-bottom: 0.1in; background: transparent; line-height: 115%; orphans: 2; widows: 2; background: transparent; page-break-before: always">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Translate + Revise
-</span></b></span></font></font></span></font></span></font></font></font>
+<body lang="en-US" dir="ltr"><p align="left" style="font-variant: normal; font-style: normal; line-height: 115%; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always">
+<font color="#000000"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Translate
++ Revise </span></b></font></font></font>
 </p>
-<p align="left" style="margin-bottom: 0.1in; background: transparent; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">One
-to three translators </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">will
+<p align="left" style="font-weight: normal; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto"><a name="docs-internal-guid-46a34c4a-7fff-518a-9f3b-69e9757ab58b"></a>
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">One
+to three translators </span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">will
 control or hold the phone and do the work for this phase, the same
-one(s) who did the LEARN phase. At least one of the translators needs
-to know the source language. This same translato</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">r</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-will also be available for any revision work recommended from the
-COMMUNITY and ACCURACY CHECK phases. </span></span></span></font></font></span></font></span></font></font></font>
+one(s) who did the LEARN phase. &nbsp;At least one of the translators
+needs to know the source language. This same translator will also be
+available for any revision work recommended from the COMMUNITY and
+ACCURACY CHECK phases.&nbsp;</span></span></font></font></span></span></font></p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+&nbsp;The purpose of the TRANSLATE + REVISE phase is to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">orally
+translate drafts of the story in smaller chunks,</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">slide
+by slide. This is also the place to learn and decide how to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">render
+difficult words and names</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">.
+Also, </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">revisions
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">to
+the translation draft will be recorded here during and</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">after
+the checks.&nbsp;&nbsp;</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
 </p>
-<p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the TRANSLATE + REVISE phase is to </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">orally
-translate</span></b></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-drafts of</b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">
-the story in smaller chunks,</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font size="3" style="font-size: 12pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-</span></span></span></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">slide
-by slide. </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">This
-is also the place to learn and decide how to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>render difficult words and names</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">Also,
-</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">revisions
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">to
-the translation draft will be recorded here during and after the checks.</span></span></span></font></font></span></font></span></font></font></font>
-</p>
-<p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Translate
-	the story.</span></b></span></font></font></span></font></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-		the mid-screen triangle play button to listen to</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-		the audio narration and/or read the text narration for </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">a
-		</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">slide.
-		Put the meaning in your mind. &nbsp;Repeat as necessary.</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">At
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Translate
+	the story.</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+		the mid-screen triangle play button to listen to the audio
+		narration and/or read the text narration for a slide. Put the
+		meaning in your mind. &nbsp;Repeat as necessary.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">At
 		the bottom of the screen, tap the mic button and record naturally
-		in </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-		local </font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">language
-		the meaning for the slide. &nbsp;Revise and repeat as necessary.</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
+		in the local language the meaning for the slide. &nbsp;Revise and
+		repeat as necessary.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
 		the triangle playback button to listen to your recording. &nbsp;Can
 		you hear it clearly? Is the translation natural? If not, record
-		again.</span></span></span></font></font></span></font></span></font></font></font></p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">
-		Decide how to render difficult words and names.
-	</span></b></span></font></font></span></font></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-		hyperlinked words to activate the</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">
-		Word Links</span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-		tool to assist with consistent renderings across all the stories.</font></font></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tapping
+		again.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Decide
+	how to render difficult words and names.&nbsp;&nbsp;</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent">
+		<span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
+		</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">a
+		blue or white </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">hyperlinked
+		word to activate the Word Links tool. </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Using</span></span></span></font></font></span></font></span><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		Word Links</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">will
+		assist your translation team to </font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">render</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">difficult</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">words
+		and names</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">consistently</font></font><font face="Arial, sans-serif"><font size="2" style="font-size: 11pt">
+		in all the stories.</font></font> 
+		</p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tapping
 		a blue hyperlink will open a popup window with notes and example
-		renderings from other languages. You can tap the mic at the bottom
-		of the Word Links screen to record how to say the term or name in your
-		local language. Also then type in a source language back translation
-		for the key term or spell how you are pronouncing names. Submit the
-		text.</font></font></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tapping
-		a white or clear hyperlink will open a popup window to the already recorded
-		audio and text renderings for the word or name.</font></font></font></font></font></p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Customize
-	the title slide.</span></b></span></font></font></span></font></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Snap
+		renderings from other languages.&nbsp; You can tap the mic at the
+		bottom of the Word Links screen to record how to say the term or
+		name in your local language. Also then type in a source language
+		back translation for the key term or spell how you are pronouncing
+		names.&nbsp; Submit the text.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tapping
+		a white or clear hyperlink will open a popup window to the already
+		recorded audio and text renderings for the word or name.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Customize
+	the title slide (or ask the Community to assist with this).</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Snap
 		a photo of a design or color, landscape or view to insert as the
-		background to the title. (Turn your phone sideways/landscape when you snap a photo.)</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Think
+		background to the title.&nbsp; (Turn your phone sideways/landscape
+		when you snap a photo.) &nbsp;</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Think
 		of a clever title that will attract people to want to listen to
 		this story. &nbsp;Type the title words in your language. Record the
-		title to match the text.</span></span></span></font></font></span></font></span></font></font></font></p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Add
-	a song to the end of your story.</span></b></span></font></font></span></font></span></font></font></font></p>
-	<ul>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Discuss
+		title to match the text.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Add
+	a song to the end of your story (or leave this for the Community to
+	do).</span></b></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Discuss
 		the content and meaning of the story. &nbsp;Compose a song that
 		will help you and others remember the message for this story.
-		&nbsp;Record your song.</span></span></span></font></font></span></font></span></font></font></font></p>
-		<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Snap
+		&nbsp;Record your song.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Snap
 		a photo of the singers or insert a picture to view while listening
-		to the song.</span></span></span></font></font></span></font></span></font></font></font></p>
-	</ul>
-	<li><p align="left" style="margin-bottom: 0.1in; background: transparent; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b>Swipe
-	down to the COMMUNITY WORK phase </b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal">or
+		to the song.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Swipe
+	down to the COMMUNITY WORK phase </span></b><span style="background: transparent">or
 	use the drop down menu on the top of the screen to tap to another
-	phase. </span></span></font></font></span></font></span></font></font></font>
-	</p>
-</ul>
-<p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
+	phase.&nbsp;</span></font></font></font></p>
+</ol>
+<p style="margin-left: 0.04in"><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
 <ul>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Swipe
-	right and left to move from slide to slide, from picture to picture.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Slides
-	are numbered in the lower right corner of the picture.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
-	can swipe one more time after the last</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">slide
-	to be back to the beginning of the story.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
-	the</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">play
-	button in the lower corner of the image to listen to the
-	script/narration for that slide. The audio narration is essentially
-	the same meaning as the written text. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
-	written text </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">may
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">have
-	some extra notes, implied information, clarified pronouns or
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Swipe
+	right and left to move from slide to slide, from picture to picture.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Slides
+	are numbered in the lower right corner of the picture.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
+	can swipe one more time after the last slide to be back to the
+	beginning of the story.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+	the play button in the lower corner of the image to listen to the
+	script/narration for that slide. &nbsp;The audio narration is
+	essentially the same meaning as the written text.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">The
+	written text may have some extra notes, implied information,
+	clarified pronouns,</span></font><span style="background: transparent">
+	</span><font face="Arial"><span style="background: transparent">or
 	alternative ways of saying the meaning in square brackets. The
 	translator(s) can choose to translate or not translate the
 	information in square brackets, depending on what is meaningful and
-	helpful in their language.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
+	helpful in their language.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
 	must translate the entire text or meaning for the slide in one
-	recording. &nbsp;You cannot pause and resume your recording.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">may</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	record as many translation drafts as you need to until you are
-	satisfied.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">The
+	recording. &nbsp;You cannot pause and resume your recording.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
+	may record as many translation drafts as you need to until you are
+	satisfied.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">The
 	app will automatically save all audio translation drafts. The most
-	recent (the last) translation recording will always be </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	selected default</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">,
-	unless you manually choose another draft from the play list.</span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
+	recent (the last) translation recording will always be the selected
+	default, unless you manually choose another draft from the play</span></font><span style="background: transparent">
+	</span><font face="Arial"><span style="background: transparent">list.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">You
 	can review all drafts by tapping the listplay icon on the lower
 	right of the screen. &nbsp;You can play, delete, rename (press and
-	hold, then type), and select drafts (to be </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	default</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">)
-	from the list window.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; background: transparent; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">You
+	hold,</span></font><span style="background: transparent"> </span><font face="Arial"><span style="background: transparent">then
+	type),</span></font><span style="background: transparent"> </span><font face="Arial"><span style="background: transparent">and
+	select drafts (to be the default) from the list window.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">You
 	can scroll within the screen by pressing and scrolling
 	simultaneously. &nbsp;You might need to do this if the text is more
 	than can fit on the screen or if there are many drafts in the list
-	window.</span></span></span></font></font></span></font></span></font></font></font></p>
+	window.</span></font></font></font></p>
 </ul>
-<p align="left" style="margin-bottom: 0.1in; background: transparent; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
+<p align="left" style="line-height: 115%; orphans: 2; widows: 2; background: transparent">
 <br/>
 <br/>
 

--- a/app/src/main/assets/voice_studio.html
+++ b/app/src/main/assets/voice_studio.html
@@ -3,172 +3,164 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.0.3 (Windows)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-02-28T10:10:58.737000000"/>
+	<meta name="changed" content="2021-12-16T21:02:09.426000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; line-height: 115%; background: transparent }
-		h3 { margin-top: 0.1in; margin-bottom: 0.08in; line-height: 100%; background: transparent; page-break-after: avoid }
-		h3.western { font-family: "Liberation Serif", serif; font-size: 14pt; font-weight: bold }
-		h3.cjk { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
-		h3.ctl { font-family: "Liberation Serif"; font-size: 14pt }
-		a:link { color: #000080; so-language: zxx; text-decoration: underline }
-		a:visited { color: #800000; so-language: zxx; text-decoration: underline }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		a:link { so-language: zxx }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><p align="left" style="line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: always; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><b><span style="background: transparent">Voice
-Studio</span></b></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Anybody
-</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">who
+<body lang="en-US" dir="ltr"><p align="left" style="font-variant: normal; font-style: normal; line-height: 115%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; text-decoration: none; page-break-before: always; page-break-after: auto">
+<font color="#000000"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><b><span style="background: transparent">Voice
+Studio</span></b></font></font></font></p>
+<p align="left" style="font-weight: normal; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent; page-break-before: auto; page-break-after: auto"><a name="docs-internal-guid-8d113e97-7fff-c584-f683-88277e939bd8"></a>
+<font color="#000000"><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Who</span></b></u></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+</span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">Anybody
+</span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">who
 speaks the language well and has a good voice can be involved in this
-phase. &nbsp;Probably </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">the
-phone </span></b></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>manager
-</b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">will
+phase. Probably </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">the
+phone manager </span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">will
 want to organize and facilitate the people doing the dramatized
-recording for this phase.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:
-The purpose of the Voice Studio phase is to </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">dramatically
-re-record the approved translation </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">with
+recording for this phase.</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+&nbsp;The purpose of the Voice Studio phase is to </span></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">dramatically
+re-record the approved translation </span></b></span></font></font></span></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">with
 better audio quality and more expressive voices. &nbsp;If desired,
-use </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">multiple
-</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">voices
-for the different characters and add sound effects in the background
-while re-recording the story.</span></span></span></font></font></span></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Noise
-	control</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Get
+use multiple voices for the different characters and add sound
+effects in the background while re-recording the story.&nbsp;&nbsp;</span></span></font></font></span></span></font></p>
+<p><br/>
+<br/>
+
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Noise
+	control</span></b><span style="background: transparent">.&nbsp; Get
 	in a place that is quiet and where you will not be interrupted by
-	people or distracting noises. </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">If
-	necessary, u</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">se
-	a </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><span style="font-weight: normal"><span style="background: transparent">blanket or towel
-	</span></span></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent"> under
-	the phone and over the head of those recording to reduce echo or
-	distracting noises. Narrators and voice actors should drink a little water before recording each slide to reduce unwanted “sticky” mouth noises.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Listen</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">For
-	each slide, tap the play button at the bottom of the picture.
-	&nbsp;Listen to the approved translation as it plays.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Practise
-	dramatized narration. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Listen
+	people or distracting noises. If necessary, use a </span><u><span style="background: transparent">blanket
+	</span></u><span style="background: transparent">under the phone and
+	over the head of those recording to reduce echo or distracting
+	noises.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Listen</span></b><span style="background: transparent">.&nbsp;
+	For each slide, tap the play button at the bottom of the picture.
+	&nbsp;Listen to the approved translation as it plays.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Practise
+	dramatized narration.&nbsp; </span></b><span style="background: transparent">Listen
 	to and memorize and practise saying as much of the translation as
-	you can. Tap to pause playback as necessary. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Record
-	dramatically. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">At
+	you can. Tap to pause playback as necessary.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Record
+	dramatically.&nbsp; </span></b><span style="background: transparent">At
 	the bottom of the screen, tap the mic button and re-record the
 	translation with a clear voice and dramatic expression. &nbsp;(Others
 	can add sound effects at the same time). Tap pause when you are
-	finished.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Practise
-	smaller chunks. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Again
+	finished.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Practise
+	smaller chunks.&nbsp; </span></b><span style="background: transparent">Again
 	tap the play button in the middle of the picture to resume listening
-	and memorizing the next part of the draft.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Resume
-	recording dramatically. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">To
-	resume dramatic re-recording, tap the mic</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><span style="background: transparent">+</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	button at the bottom of the screen. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Finish
-	recording. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">To
+	and memorizing the next part of the draft.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Resume
+	recording dramatically. </span></b><span style="background: transparent">&nbsp;To
+	resume dramatic re-recording, tap the mic</span><font size="4" style="font-size: 14pt"><span style="background: transparent">+</span></font><span style="background: transparent">
+	button at the bottom of the screen.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Finish
+	recording. </span></b><span style="background: transparent">&nbsp;To
 	end the dramatic re-recording, tap the square stop button at the
-	bottom right of the screen.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Replay
-	recording at any time. </b></font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Tap
+	bottom right of the screen.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Replay
+	recording at any time. </span></b><span style="background: transparent">Tap
 	the triangle play button at the bottom of the screen to listen to
 	your dramatic re-recording. &nbsp;If you are satisfied with the
 	quality, swipe to the next slide. If you are not satisfied with the
 	quality of the recording, repeat the listening and dramatic
-	re-recording process.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Re-play
-	and proof check all slides.</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-	</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Before
-	moving to the Finalize phase, double check that you are satisfied
-	with the dramatic audio volume and quality by replaying all the
-	slides one after the other. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Optional
-	story transcription or text narration.</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">
+	re-recording process.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Re-play
+	and proof check all slides.</span></b><span style="background: transparent">&nbsp;
+	Before moving to the Finalize phase, double check that you are
+	satisfied with the dramatic audio volume and quality by replaying
+	all the slides one after the other.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Optional
+	story transcription or text narration.</span></b><span style="background: transparent">&nbsp;
 	For every slide, under the picture, there is the option to type the
-	audio narration into text. Play the approved draft and pause to type
-	the words. Play, pause and type until each slide has been
-	transcribed. It is suggested that only languages that have a stable
-	orthography or alphabet should do this option. If you want to
-	produce a video that has the story written in text on the bottom of
-	each slide, you will need to select the appropriate option in the
-	FINALIZE phase. </font></font></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Optional
-	song re-record</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
+	audio narration into text.&nbsp; Play the approved draft and pause
+	to type the words.&nbsp; Play, pause, and type until each slide has
+	been transcribed.&nbsp; It is suggested that only languages that
+	have a stable orthography or alphabet should do this option. If you
+	want to produce a video that has the story written in text on the
+	bottom of each slide, you will need to select the appropriate option
+	in the FINALIZE phase.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Optional
+	song re-record</span></b><span style="background: transparent">.&nbsp;
 	If the original recording of the song sounds good, it does not need
-	to be re-recorded. However, the community might want to re-record
-	the song with more instruments and voices etc. To include the song
-	at the end of the story, be sure to select the appropriate &ldquo;Include
-	Local Song&rdquo; option in the FINALIZE phase. </font></font></font></font></font>
-	</p>
-</ul>
-</p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">:</span></span></span></font></font></span></font></span></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">To
-	stop a recording, you must tap the square stop button.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">When
-	a recording is paused, it will resume recording when the mic</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><span style="background: transparent">+</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">
-	</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">button
-	is tapped.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">To
-	start a new recording, the mic button must not have a </span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="3" style="font-size: 12pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">+</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	next to it. Tap </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-	square stop button to refresh the recording button.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto"><a name="_30j0zll"></a>
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">To
-	resume a recording the mic</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="4" style="font-size: 14pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">+</span></span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">
-	button must </span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">be
-	displayed</font></font><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">.</span></span></span></font></font></span></font></span></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">Sound
-	effects (e.g. crowd noises, chickens crowing) can only be added
-	simultaneously with recording the dramatized narration. The
-	</span></span></span></font></font></span></font></span><font face="Arial, serif"><font size="2" style="font-size: 11pt">background
-	music which comes with the template usually has some sound effects. </font></font></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="font-weight: normal"><span style="background: transparent">If
-	you find that your newly created video has dubbing mistakes or it
-	does not have good audio quality, you can always return to this
-	phase and re-dramatize any or all of the slides. </span></span></span></font></font></span></font></span></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2; background: transparent">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">If
-	a slide is not re-recorded, when a video is created, the approved
-	translation draft is what will play for that slide.</font></font></font></font></font></p>
-</ul>
-<h3 class="western" align="left" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-after: auto">
-<br/>
+	to be re-recorded.&nbsp; However, the community might want to
+	re-record the song with more instruments and voices etc.&nbsp; To
+	include the song at the end of the story, be sure to select the
+	appropriate &ldquo;Include Local Song&rdquo; option in the FINALIZE
+	phase.&nbsp;</span></font></font></font></p>
+</ol>
+<p style="margin-left: 0.04in"><br/>
 <br/>
 
-</h3>
+</p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ul>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">To
+	stop a recording, you must tap the square stop button.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">When
+	a recording is paused, it will resume recording when the mic</span></font><font face="Arial"><font size="4" style="font-size: 14pt"><span style="background: transparent">+</span></font></font><span style="background: transparent">
+	&nbsp;</span><font face="Arial"><span style="background: transparent">button
+	is tapped.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">To
+	start a new recording, the mic button must not have a </span></font><font face="Arial"><font size="3" style="font-size: 12pt"><span style="background: transparent">+</span></font></font><span style="background: transparent">
+	</span><font face="Arial"><span style="background: transparent">next
+	to it.&nbsp; Tap the square stop button to refresh the recording
+	button.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Noto Sans Symbols, sans-serif"><font size="2" style="font-size: 11pt"><font face="Arial"><span style="background: transparent">To
+	resume a recording the mic</span></font><font face="Arial"><font size="4" style="font-size: 14pt"><span style="background: transparent">+</span></font></font><span style="background: transparent">
+	</span><font face="Arial"><span style="background: transparent">button
+	must be displayed.</span></font></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Sound
+	effects (e.g. crowd noises, chickens crowing) can only be added
+	simultaneously with recording the dramatized narration.&nbsp; The
+	background music which comes with the template usually has some
+	sound effects.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	you find that your newly created video has dubbing mistakes or it
+	does not have good audio quality, you can always return to this
+	phase and re-dramatize any or all of the slides.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">If
+	a slide is not re-recorded, when a video is created, the approved
+	translation draft is what will play for that slide.</span></font></font></font></p>
+</ul>
+<p align="left" style="line-height: 138%; orphans: 2; widows: 2; margin-bottom: 0in; background: transparent">
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/assets/word_links.html
+++ b/app/src/main/assets/word_links.html
@@ -1,226 +1,236 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<meta http-equiv="content-type" content="text/html; charset=windows-1252"/>
 	<title></title>
-	<meta name="generator" content="LibreOffice 6.2.1.2 (Linux)"/>
+	<meta name="generator" content="LibreOffice 7.2.4.1 (Windows)"/>
 	<meta name="created" content="2019-02-28T10:05:36.323000000"/>
-	<meta name="changed" content="2019-04-02T16:55:08.972750319"/>
+	<meta name="changed" content="2022-01-19T15:17:06.024000000"/>
 	<style type="text/css">
-		@page { size: 8.5in 11in; margin: 0.79in }
-		p { margin-bottom: 0.1in; background: transparent; line-height: 115%; background: transparent }
-		h3 { margin-top: 0.1in; margin-bottom: 0.08in; background: transparent; line-height: 100%; background: transparent; page-break-after: avoid }
-		h3.western { font-family: "Liberation Serif", serif; font-size: 14pt; font-weight: bold }
-		h3.cjk { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
-		h3.ctl { font-family: "Liberation Serif"; font-size: 14pt; font-weight: bold }
+		@page { margin: 0.79in }
+		p { line-height: 115%; margin-bottom: 0.1in; background: transparent }
+		h3 { line-height: 100%; margin-top: 0.1in; margin-bottom: 0.08in; background: transparent }
+		h3.western { font-family: "Liberation Serif", serif }
+		h3.cjk { font-family: "Liberation Serif" }
+		h3.ctl { font-family: "Liberation Serif" }
 	</style>
 </head>
-<body lang="en-US" link="#000080" vlink="#800000" dir="ltr"><h3 class="western" style="margin-top: 0.22in; margin-bottom: 0.06in; line-height: 138%; page-break-before: always">
-	<font face="Arial, serif">Word Links</font>
+<body lang="en-US" dir="ltr"><h3 class="western" style="line-height: 138%; margin-top: 0.22in; margin-bottom: 0.06in; page-break-before: always">
+<font face="Arial, serif">Word Links</font> 
 </h3>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Who</b></u></font></font><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">:
-</span></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Translators
-</b></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">and
-</span></font></font></span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Accuracy
-checkers</b></font></font></span><span style="text-decoration: none">
-</span><span style="text-decoration: none"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><span style="font-weight: normal">will
-find this tool or feature helpful to utilize.</span></font></font></span></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Purpose</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:
-		The purpose of the Word Links tool is to provide </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>convenient
-		access </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">to
-		key terms across all the stories and to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>build
-		a database </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">of
-		audioized</font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">local
-		language renderings for key terms in a single location. And to assist
-		translators to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>render
-		Biblical key terms consistently</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">and
-		to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>pronounce
-		people and place names consistently</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">in/across
-		all the stories. Also, to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>provide
-		literal text back-translations</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">for
-		all key terms (and transliterations of names) as another means to
-		help an Accuracy Checker in their work.</font></font></font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Activities</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:</font></font></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; page-break-inside: auto; orphans: 2; widows: 2; background: transparent; page-break-before: auto; page-break-after: auto">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>From
-			the sidebar menu, Word Links list: </b></font></font></font>
-	</p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Type
-					in the search bar to find a specific key term or name, or scroll
-					through the alphabetized terms to find what you are looking for.</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-					a word/name to open the Key Term popup window for that term.</font></font></font></p>
-		</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Tap
-			a hyperlinked term</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">from
-			the TRANSLATE or ACCURACY CHECK phase, text section of each slide.</font></font></font></font></font></p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">A
-				</font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>blue
-					hyperlink</u></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">indicates
-					that there is no audio rendering for that term. Tapping a blue
-					hyperlink will navigate the user to the research screen for the
-					term.</font></font></font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">A
-				</font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>clear
-					hyperlink</u></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">(underlined
-					normal text) indicates that an audio rendering (at least one) has
-					been made for that term. Tapping a clear hyperlink will navigate
-					the user to the audio and text documentation screen for the term.
-					Slide up to see the research screen.</font></font></font></font></font></p>
-		</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Read
-			and research</b></font></font> <font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-			meaning of a term. </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Discuss
-		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">how
-			to render the term in the context of the story in the local
-			language. </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Consider
-		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">other
-			related but different terms.</font></font></font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Document
-			a local language key term</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-		</font></font></font></font></font>
-	</p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-					the mic button at the bottom of the screen to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>record
-				</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">an
-					audio translation of the term in the local language. Tap the square
-					button to stop the recording. </font></font></font></font></font>
-			</p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-					inside the companion text box to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>type
-				</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">a
-					word-for-word literal back translation in the source language (LWC)
-					of the audio rendering for the key term. Or, if a name was
-					recorded, type a (phonetic) transliteration of the word.</font></font></font></font></font></p>
-		</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Recall
-			how a term was rendered. </b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">Tap
-			a clear hyperlink to open the Key Term popup window, documentation
-			screen. Tap the triangle play button to </font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>listen
-		</u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">to
-			how a name or term was rendered in another story. Exit the Word Link popup
-			window to resume translation work. </font></font></font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>Exit
-		</b></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">the
-			Key Term Tracker popup window by tapping the X in the upper right
-			corner of the screen. Resume your translation and checking
-			activities. Or sometimes, tapping the back arrow on your phone will
-			put you back where you just came from.</font></font></font></font></font></p>
-</ul>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u><b>Notes</b></u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">:</font></font></font></font></font></p>
-<ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-			The Word Links database notes are intended to be non-encyclopedic in nature -- just a few notes to give translators essential and basic meaning or background.  If there is an existing local language Scripture translation or Bible translation team, these should always be consulted so there is consistency in how terms and names are rendered in the stories.
-		</font></font></font></p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Two
-			types of words are included in the Word Links database:</font></font></font></p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>Biblical</u></font></font>
-					<font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>key</u></font></font>
-					<font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>terms</u></font></font><font face="Arial, serif"><font size="2" style="font-size: 11pt">.
-						Some of these terms may have multiple senses depending on their
-						context. Translators may need to record multiple audio renderings
-						for one key term and discern which rendering to use in which
-						context. Multiple audio renderings might also need to be recorded
-						to document different forms of a term (e.g. verb form and noun
-						form)</font></font></font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Liberation Serif, serif"><font size="3" style="font-size: 12pt"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><u>Names</u></font></font>
-					<font face="Arial, serif"><font size="2" style="font-size: 11pt">for
-						people and places. The primary purpose for recording an audio
-						rendering for names is to provide consistency in pronunciation
-						across all the stories.</font></font></font></font></font></p>
-		</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">There
-			are several sections in the Word Links Tracker popup window Research
-			screen to aid the story translator in their decision for how to
-			render the term:</font></font></font></p>
-		<ul>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">The
-					hyperlinked word from the story followed by its various grammatical
-					forms. These will be at the top of the popup window in the red section. </font></font></font>
-			</p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Notes
-					-- brief definitions or background information.</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Related
-					(but different) terms, hyperlinked -- to provide some material for
-					comparison and contrast, further research.</font></font></font></p>
-			<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-				<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Example
-					renderings from other languages, back translated -- to provide
-					practical ideas for how story translators might want to translate
-					the term in their local language.</font></font></font></p>
-		</ul>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">The
-			recording bar at the bottom of the screen will expand into an
-			extended screen below the research screen once a recording has been
-			made for a key term. Once audio renderings have been recorded for a
-			term, they can be reviewed in this extended documentation screen --
-			the audio rendering in the local language can be listened to and the
-			associated back-translated text can be read. </font></font></font>
-	</p>
-	<li><p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-		<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-			The Word Links local language database could be backed up on a regular basis.  The WordLinks folder is located in the root of the SP Templates directory which is usually stored on the SD card. For backup, copy the WordLinks directory to another drive or card.
-		</font></font></font>
-	</p>
-</ul>
+<p align="left" style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 138%; orphans: 2; widows: 2; margin-bottom: 0in; text-decoration: none"><a name="docs-internal-guid-cdaf3aa4-7fff-d9f7-78f7-854c32f144e4"></a>
+<font color="#000000"><font face="Liberation Serif"><font size="3" style="font-size: 12pt"><font face="Arial"><font size="2" style="font-size: 11pt"><u><b><span style="background: transparent">Who</span></b></u></font></font><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">:
+</span></font></font><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Translators
+</span></b></font></font><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">and
+</span></font></font><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Accuracy
+checkers</span></b></font></font><span style="background: transparent">
+</span><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">will
+find this tool or feature helpful to utilize.</span></font></font></font></font></font></p>
+<p style="border: none; padding: 0in; background: transparent"><br/>
+<br/>
 
 </p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt"><b>
-		Word Links (Key Term) Database copyright and license:
-	</b>
-	</font></font></font>
-</p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">
-		Word Links (Key Term) Database including back translation contributions from the
-		following languages: </font></font></font>
-</p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Daasanach
-		(D), Wolof (W), Guajajara (G), Kandas (K) and Ramoaaina (R)</font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Purpose</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:
+The purpose of the </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#cc0000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">Word
+Links</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">tool
+is to provide </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">convenient
+access </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">to
+difficult words and names across all the stories and to </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">build
+a database </span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">of
+audioized</span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">local
+language renderings for difficult words and names in a single
+location.&nbsp; And to assist translators to </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">render
+Biblical key terms consistently</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">and
+to </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">pronounce
+people and place names consistently</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">in/across
+all the stories.&nbsp; Also, to </span></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">provide
+literal text ba</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#cc0000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">ck-tra</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: transparent">nslations</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: transparent">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">for
+all the difficult words and names (and transliterations of names) as
+another means to help an Accuracy Checker in their work.</span></span></font></font></span></font></span></p>
+<p><br/>
+<br/>
 
 </p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">©
-		2019 Wycliffe Bible Translators, Inc.</font></font></font></p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<span style="font-variant: normal"><font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Activities</span></b></u></span></font></font></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></font></span></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">From
+	the sidebar menu, Word Links</span></b><span style="background: transparent">
+	</span><b><span style="background: transparent">list: </span></b><span style="background: transparent">&nbsp;</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Type
+		in the search bar to find a specific term or name, or scroll
+		through the alphabetized words to find what you are looking for.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+		a word/name to open the popup window for that term.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Tap
+	a hyperlinked term</span></b><span style="background: transparent">
+	from the TRANSLATE or ACCURACY CHECK phase, text section of each
+	slide.</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
+		</span><u><span style="background: transparent">blue hyperlink</span></u><span style="background: transparent">
+		indicates that there is no audio rendering for that term.&nbsp;
+		Tapping a blue hyperlink will navigate the user to the research
+		screen for the term.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">A
+		</span><u><span style="background: transparent">clear hyperlink</span></u><span style="background: transparent">
+		(underlined normal text) indicates that an audio rendering (at
+		least one) has been made for that term.&nbsp; Tapping a clear
+		hyperlink will navigate the user to the audio and text
+		documentation screen for the term. Slide up to see the research
+		screen.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Read
+	and research</span></b><span style="background: transparent"> the
+	meaning of a term.&nbsp; </span><b><span style="background: transparent">Discuss
+	</span></b><span style="background: transparent">how to render the
+	term in the context of the story in the local language. </span><b><span style="background: transparent">Consider
+	</span></b><span style="background: transparent">other related but
+	different terms.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Document
+	a local language term or word</span></b><span style="background: transparent">.&nbsp;&nbsp;</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Tap
+		the mic button at the bottom of the screen to </span><b><span style="background: transparent">record
+		</span></b><span style="background: transparent">an audio
+		translation of the term in the local language.&nbsp; Tap the square
+		button to stop the recording.&nbsp;</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Press
+		and hold on the audio file</span><span style="background: transparent">
+		to </span><b><span style="background: transparent">type </span></b><span style="background: transparent">a
+		word-for-word literal back translation in the source language
+		(LWC).&nbsp; Or, if a name was recorded, type a (phonetic)
+		transliteration of the word.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Recall
+	how a word was rendered.&nbsp; </span></b><span style="background: transparent">Tap
+	a clear hyperlink to open the Word Link popup window, documentation
+	screen.&nbsp; Tap the triangle play button to </span><u><span style="background: transparent">listen
+	</span></u><span style="background: transparent">to how a name or
+	term was rendered in another story.&nbsp; Exit the popup window to
+	resume translation work.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Exit
+	</span></b><span style="background: transparent">the Word Link popup
+	window by tapping the X in the upper right corner of the screen.
+	Resume your translation and checking activities.&nbsp; Or sometimes,
+	tapping the back arrow on your phone will put you back where you
+	just came from.</span></font></font></font></p>
+</ol>
+<p><br/>
+<br/>
 
 </p>
-<p align="left" style="margin-bottom: 0in; line-height: 138%; orphans: 2; widows: 2">
-	<font color="#000000"><font face="Arial, serif"><font size="2" style="font-size: 11pt">Licensed
-		under the terms of a Creative Commons Attribution-ShareAlike 4.0
-		International license.</font></font></font></p>
+<p style="font-weight: normal; line-height: 165%; margin-bottom: 0in">
+<font color="#000000"><span style="font-variant: normal"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: transparent">Notes</span></b></u></span></font></font></span><span style="font-variant: normal"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><span style="background: transparent">:</span></span></font></font></span></span></font></p>
+<ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	Word Links database notes are intended to be non-encyclopedic in
+	nature -- just a few notes to give translators essential and basic
+	meaning or background.&nbsp; If there is an existing local language
+	Scripture translation or Bible translation team, these should always
+	be consulted so there is consistency in how terms and names are
+	rendered in the stories.</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Two
+	types of words are included in the Word Links database:</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><u><span style="background: transparent">Biblical</span></u><span style="background: transparent">
+		</span><u><span style="background: transparent">key</span></u><span style="background: transparent">
+		</span><u><span style="background: transparent">terms</span></u><span style="background: transparent">.&nbsp;
+		Some of these terms may have multiple senses depending on their
+		context.&nbsp; Translators may need to record multiple audio
+		renderings for one key term and discern which rendering to use in
+		which context.&nbsp; Multiple audio renderings might also need to
+		be recorded to document different forms of a term (e.g. verb form
+		and noun form)</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><u><span style="background: transparent">Names</span></u><span style="background: transparent">
+		for people and places. The primary purpose for recording an audio
+		rendering for names is to provide consistency in pronunciation
+		across all the stories.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">There
+	maybe several sections in the Word Links popup window Research
+	screen to aid the story translator in their decision for how to
+	render the term:</span></font></font></font></p>
+	<ol type="a">
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+		hyperlinked word from the story followed by its various grammatical
+		forms.&nbsp; These will be at the top of the popup window in the
+		red section.&nbsp;</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Notes
+		-- brief definitions or background information.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Related
+		(but different) terms, hyperlinked -- to provide some material for
+		comparison and contrast, further research.</span></font></font></font></p>
+		<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+		<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">Example
+		renderings from other languages, back translated -- to provide
+		practical ideas for how story translators might want to translate
+		the term in their local language.</span></font></font></font></p>
+	</ol>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	recording bar at the bottom of the screen will expand into an
+	extended screen below the research screen once a recording has been
+	made for a key term.&nbsp; Once audio renderings have been recorded
+	for a term, they can be reviewed in this extended documentation
+	screen -- the audio rendering in the local language can be listened
+	to and the associated back-translated text can be read.&nbsp;</span></font></font></font></p>
+	<li><p style="font-variant: normal; font-style: normal; font-weight: normal; line-height: 165%; margin-bottom: 0in; border: none; padding: 0in; background: transparent; text-decoration: none">
+	<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="background: transparent">The
+	Word Links local language database could be backed up on a regular
+	basis.&nbsp; The WordLinks folder is located in the root of the SP
+	Workspace directory (which is maybe stored on the SD card). For
+	backup, copy the WordLinks directory to another drive or card.&nbsp;&nbsp;</span></font></font></font></p>
+</ol>
+<p><br/>
+<br/>
+
+</p>
+<p style="font-variant: normal; font-style: normal; line-height: 165%; margin-left: 0.5in; margin-bottom: 0in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: transparent">Word
+Links (Key Term) Database copyright and license:</span></b></font></font></font></p>
+<p style="font-variant: normal; font-style: normal; line-height: 165%; margin-left: 0.5in; margin-bottom: 0in; text-decoration: none">
+<font color="#000000"><font face="Arial"><font size="2" style="font-size: 11pt"><b><span style="background: #ffffff">Word
+Links (Key Term) Database including back translation contributions
+from the following languages:&nbsp; Daasanach (D), Wolof (W),
+Guajajara (G), Kandas (K) and Ramoaaina (R). &copy; 2019 Wycliffe
+Bible Translators, Inc.</span></b></font></font></font></p>
+<p style="line-height: 165%; margin-left: 0.5in; margin-bottom: 0in"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: #ffffff">Licensed
+under the terms of a</span></b></span></font></font></span></font></span><a href="https://creativecommons.org/licenses/by-sa/4.0/"><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: #ffffff">
+</span></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><u><b><span style="background: #ffffff">Creative
+Commons Attribution-ShareAlike 4.0 International license</span></b></u></span></font></font></span></font></span></a><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><font face="Arial"><font size="2" style="font-size: 11pt"><span style="font-style: normal"><b><span style="background: #ffffff">.</span></b></span></font></font></span></font></span><span style="font-variant: normal"><font color="#000000"><span style="text-decoration: none"><span style="background: #ffffff">&nbsp;</span></span></font></span></p>
+<p style="font-weight: normal"><font color="#000000"><br/>
+</font><br/>
+<br/>
+
+</p>
 </body>
 </html>

--- a/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/RegistrationActivity.kt
@@ -6,25 +6,33 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings.Secure
 import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.webkit.WebView
 import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.GravityCompat
 import com.android.volley.Request
 import com.android.volley.Response
 import com.android.volley.toolbox.StringRequest
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.sil.storyproducer.R
+import org.sil.storyproducer.model.Phase
+import org.sil.storyproducer.model.PhaseType
 import org.sil.storyproducer.model.Workspace
 import org.sil.storyproducer.tools.Network.VolleySingleton
 import java.util.*
@@ -91,6 +99,10 @@ open class RegistrationActivity : AppCompatActivity() {
         }
 
         setContentView(R.layout.activity_registration)
+        val mActionBarToolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(mActionBarToolbar)
+        setSupportActionBar(mActionBarToolbar)
+        supportActionBar?.setTitle(R.string.registration_title)
 
         //Initialize sectionViews[] with the integer id's of the various LinearLayouts
         //Add the listeners to the LinearLayouts's header section.
@@ -112,6 +124,34 @@ open class RegistrationActivity : AppCompatActivity() {
         addSubmitButtonSave()
         addRegistrationSkip()
         addEthnologueQuestion()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_with_help, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.helpButton -> {
+                val alert = AlertDialog.Builder(this)
+                alert.setTitle("${Phase(PhaseType.REGISTRATION).getDisplayName()} Help")
+
+                val wv = WebView(this)
+                val iStream = assets.open(Phase.getHelpDocFile(PhaseType.REGISTRATION))
+                val text = iStream.reader().use {
+                    it.readText() }
+
+                wv.loadDataWithBaseURL(null,text,"text/html",null,null)
+                alert.setView(wv)
+                alert.setNegativeButton("Close") { dialog, _ ->
+                    dialog!!.dismiss()
+                }
+                alert.show()
+                true
+            }
+            else -> { true } // should never happen
+        }
     }
 
     /**

--- a/app/src/main/java/org/sil/storyproducer/model/Phase.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Phase.kt
@@ -105,6 +105,7 @@ class Phase (val phaseType: PhaseType) {
      */
     fun getDisplayName() : String {
         return when (phaseType) {
+            PhaseType.REGISTRATION     -> "Registration"
             PhaseType.LEARN            -> "Learn"
             PhaseType.TRANSLATE_REVISE -> "Translate + Revise"
             PhaseType.WORD_LINKS       -> "Word Links"

--- a/app/src/main/res/layout/activity_registration.xml
+++ b/app/src/main/res/layout/activity_registration.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,12 +9,36 @@
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:id="@+id/toolbar"
+                android:background="@color/black"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <!--*************************** Language Information ********************************-->
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="56dp"
+        android:paddingTop="24dp"
         android:paddingStart="24dp"
         android:paddingEnd="24dp">
 
-        <!--*************************** Language Information ********************************-->
+<!--        <Button-->
+<!--            android:id="@+id/help_button"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:drawableStart="@drawable/ic_help_white_24dp"-->
+<!--            android:title="@string/help" />-->
 
         <Button
             android:id="@+id/bypass_button"
@@ -292,7 +314,7 @@
             android:id="@+id/consultant_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/registration_consultant_header"
+            android:text="@string/registration_accuracy_check_header"
             android:textSize="@dimen/header_text"
             android:gravity="center"
             android:background="@color/black_semi_transparent"
@@ -592,6 +614,7 @@
             android:layout_marginBottom="8dp"
             android:text="@string/submit_via"
             android:layout_gravity="center" />
+    </LinearLayout>
     </LinearLayout>
 </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
 
 
     <!-- Phases -->
+    <string name="registration_title">Registration</string>
     <string name="learn_title">Learn</string>
     <string name="translate_revise_title">Translate + Revise</string>
     <string name="community_work_title">Community Work</string>
@@ -47,7 +48,7 @@
     <!-- String names for registration -->
     <string name="registration_language_header">Language Information</string>
     <string name="registration_translator_header">Translator Information</string>
-    <string name="registration_consultant_header">Consultant Information</string>
+    <string name="registration_accuracy_check_header">Accuracy Checker Info</string>
     <string name="registration_trainer_header">Trainer Information</string>
     <string name="registration_archive_header">Archive Information</string>
     <string name="language_hint">Language (being translated into)</string>


### PR DESCRIPTION
This pull request integrates Cedarville pull 558 into the current base line.  Pull 558 is based on #552 (Registration page - Add Help button & change drawer label).  
#552 Summary:
- add the phase menu bar to the registration activity
- update drawer name to ‘Accuracy Checker Info’
- add registration HTML help doc

This pull request also integrates #590 (Update the Help docs for Registration and Story Templates).  Per #590 all the html documents were updated to include the newest phase names and exclude references to ROCC.

Testing:
Using an Android Studio debug build, registration help menu bar was tested.  The following html help documents were reviewed and displayed: 

- accuracy_check.html
- community_work.html
- finalize.html
- learn.html
- registration.html
- share.html
- story_list.html
- translate_revise.html
- voice_studio.html
- word_links.html

Test were run on an Android11 Pixel 5 phone.

Successfully ran Espresso tests on a Pixel 2 Android 9 emulator using the debug build.

The following image shows the new Registration page:
![image](https://user-images.githubusercontent.com/78509270/151295333-7ba67d58-b438-4359-8504-c875454df2f9.png)

The following image shows the beginning of the Registration Help:
![image](https://user-images.githubusercontent.com/78509270/151295427-2b288f8c-6b43-4e08-94ba-4ba897606d61.png)
