### PR TITLE
SP-622 Fix for 'no default wordlist file'

### DIFF
--- a/app/src/main/assets/wordlinks.csv
+++ b/app/src/main/assets/wordlinks.csv
@@ -1,1 +1,0 @@
-term,Alternate forms and synonyms.,Other language examples (back translations),Meaning notes. Definitions.,Related (but different) terms,Database Copyright and license statement:,other consultant suggestions / comments / entries,Galen's rationale,Galen's notes/drafts

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -197,12 +197,14 @@ object Workspace {
 
         if (wordLinksDir != null) {
             // DKH - 11/19/2021 Issue #613 Create Word Links CSV file if it does not exist
-            // BW 2/16/2022 #622 There is no default CSV file or LWC.
+            // BW 2/21/2022 #622 There is no default CSV file or LWC.
             // In a future version, the correct CSV would be based on the user's selection
                 // of the LWC for this workspace.
-            // if(csvFileName == null) addWordLinksCSVFileToWorkspace(context, csvFileNameForSelectedLWC)
+            // if(csvFileName == null)
+            //     addWordLinksCSVFileToWorkspace(context, csvFileNameForSelectedLWC)
+
             if(csvFileName != null) {
-                // Process the CSV file
+                // Process the CSV file, read the Json file, and map the terms
                 importWordLinksFromCSV(context, wordLinksDir!!)
                 importWordLinksFromJsonFiles(context, wordLinksDir!!)
                 mapTermFormsToTerms()
@@ -328,19 +330,19 @@ object Workspace {
             }
         }
     }
-    fun addWordLinksCSVFileToWorkspace(context: Context, csvFileName: String) {
+    fun addWordLinksCSVFileToWorkspace(context: Context, csvFileNameForSelectedLWC: String) {
         // DKH - 11/19/2021 Issue #613 Create Word Links CSV file if it does not exist
-        // During compile time, the file app/src/main/assets/wordlinks.csv is compiled into
-        // the APK.  This routine extracts that file and places that file in the
-        // Worklinks directory.
-        // This routine is called anytime a ".csv" file cannot be found in the workdlinks directory
+        // BW 2/21/2022 #622 There is no default CSV file or LWC.
+        // At compile time, files such as app/src/main/assets/WordLinks - English.csv
+        // may be compiled into the APK.  This routine extracts the given file and writes that
+        // file in the Worklinks directory.
         val assetManager = context.assets
 
         try {
             // open wordlinks.csv located in the APK
-            val instream = assetManager.open(csvFileName)
+            val instream = assetManager.open(csvFileNameForSelectedLWC)
             // Create the worklinks.csv file in the wordlinks directory
-            val outstream = getChildOutputStream(context, "$WORD_LINKS_DIR/$csvFileName")
+            val outstream = getChildOutputStream(context, "$WORD_LINKS_DIR/$csvFileNameForSelectedLWC")
             val buffer = ByteArray(1024)
             var read: Int
             // copy input to output 1024 bytes at a time
@@ -350,7 +352,7 @@ object Workspace {
             outstream?.close() // close output stream
             instream.close() // close input stream
         } catch (e: Exception) {
-            Log.e("workspace", "Failed to copy wordlinks CSV asset file: $csvFileName", e)
+            Log.e("workspace", "Failed to copy wordlinks asset file: $csvFileNameForSelectedLWC", e)
         }
 
     }

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -176,18 +176,16 @@ object Workspace {
 
     private fun importWordLinks(context: Context) {
         var wordLinksDir = workdocfile.findFile(WORD_LINKS_DIR)
-        var csvFileName : String? = null  // default is no csv file, later on, create one if none found
+        var csvFileName : String? = null  // csv file name if found
 
         if (wordLinksDir == null) { // check to see if word links directory exists
             // DKH - 11/19/2021 Issue #611 Create Word Links CSV directory if it does not exist
             wordLinksDir = workdocfile.createDirectory(WORD_LINKS_DIR)
         }else{
             // DKH - 12/07/2021 Issue #611 Use the first CSV file that starts with "worklinks" & ends with "csv"
-
             // The WordLinks Directory exists, so,  see if we can find a csv file
             // CSV files start with the substring "wordlinks" and ends with ".csv"
             // scan all the files in the wordlinks directory looking for a valid csv file
-            // If we have a valid CSV file, we don't have to create the default one
             for (filename in wordLinksDir!!.listFiles()) {
                 // look for a wordlinks csv file
                 if((filename.name)?.contains(WORD_LINKS_CSV_REGEX)!!){
@@ -199,14 +197,19 @@ object Workspace {
 
         if (wordLinksDir != null) {
             // DKH - 11/19/2021 Issue #613 Create Word Links CSV file if it does not exist
-            if(csvFileName == null) addWordLinksCSVFileToWorkspace(context, WORD_LINKS_CSV)
-            // Process the CSV file
-            importWordLinksFromCSV(context, wordLinksDir!!)
-            importWordLinksFromJsonFiles(context, wordLinksDir!!)
-            mapTermFormsToTerms()
-            buildWLSTree()
+            // BW 2/16/2022 #622 There is no default CSV file or LWC.
+            // In a future version, the correct CSV would be based on the user's selection
+                // of the LWC for this workspace.
+            // if(csvFileName == null) addWordLinksCSVFileToWorkspace(context, csvFileNameForSelectedLWC)
+            if(csvFileName != null) {
+                // Process the CSV file
+                importWordLinksFromCSV(context, wordLinksDir!!)
+                importWordLinksFromJsonFiles(context, wordLinksDir!!)
+                mapTermFormsToTerms()
+                buildWLSTree()
+            }
         }else{
-            Log.e("workspace", "Failed to create word links directory: $WORD_LINKS_CSV")
+            Log.e("workspace", "Failed to create word links directory: $WORD_LINKS_DIR")
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="whole_story_title">Whole Story Back Translation</string>
     <string name="back_translation_title">Back Translation</string>
     <string name="title_activity_story_templates">Story Templates</string>
-    <string name="title_activity_wordlink_list">Word Links List</string>
+    <string name="title_activity_wordlink_list">WordLinks List</string>
 
     <!-- String names for registration -->
     <string name="registration_language_header">Language Information</string>
@@ -181,10 +181,10 @@
     <string name="wordlink_backtranslation">Backtranslation</string>
     <string name="wordlink_none">None</string>
     <string name="wordlink_list_help">None</string>
-    <string name="wordlinks_csv_read_error">Error reading word links CSV file</string>
-    <string name="wordlinks_json_read_error">Error reading word links JSON file</string>
-    <string name="wordlinks_no_csv_file">No Valid CSV WordLinks File Specified</string> <!-- SP611 CSV Error handling -->
-    <string name="wordlinks_multiple_csv_files">Detected multiple Word Links CSV Files.\nUsing:\t</string> <!-- SP611 CSV Error handling -->
+    <string name="wordlinks_csv_read_error">Error reading wordlinks CSV file</string>
+    <string name="wordlinks_json_read_error">Error reading wordlinks JSON file</string>
+    <string name="wordlinks_no_csv_file">No WordLinks CSV File Found</string> <!-- SP611 CSV Error handling -->
+    <string name="wordlinks_multiple_csv_files">Found multiple WordLinks CSV Files.\nUsing:\t</string> <!-- SP611 CSV Error handling -->
 
     <!-- Voice Studio Phase -->
     <string name="voice_studio_edit_text_hint">Write story text for videos with included text.</string>


### PR DESCRIPTION
As outlined in issue #622, for SP v3.1 there should be no default wordlist file installed automatically. 
Users will need to download and install on their phone the Wordlinks file appropriate for the LWC of their templates 