### PR TITLE
SP456-Add grey background color behind subtitles when creating an MP4…

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/tools/media/story/StoryFrameDrawer.kt
+++ b/app/src/main/java/org/sil/storyproducer/tools/media/story/StoryFrameDrawer.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.media.MediaFormat
 import android.util.Log
+import org.sil.storyproducer.model.SlideType
 import org.sil.storyproducer.model.Workspace
 import org.sil.storyproducer.service.SlideService
 import org.sil.storyproducer.tools.BitmapScaler
@@ -182,10 +183,15 @@ internal class StoryFrameDrawer(private val context: Context, private val mVideo
             canv.drawARGB((alpha * 255).toInt(), 0, 0, 0)
         }
 
-        val tOverlay = page.textOverlay
-        if (tOverlay != null) {
-            tOverlay.setAlpha(alpha)
-            tOverlay.draw(canv)
+        page.textOverlay.let{
+            // 2/22/2022 - DKH, Issue 456: Add grey rectangle to backdrop text "sub titles"
+            // If this is a NUMBEREDPAGE type slide, draw a background behind the text so
+            // that it can be clearly read in the video that we are creating
+            // Other pages (eg: NONE, FRONTCOVER, LOCALSONG, LOCALCREDITS, COPYRIGHT, ENDPAGE),
+            // do not need a background for the text
+            if (page.sType == SlideType.NUMBEREDPAGE) it?.drawTextBG(true)
+            it?.setAlpha(alpha)
+            it?.draw(canv)
         }
     }
 


### PR DESCRIPTION
Per Issue #456, update Story Producer to provide a semi-transparent grey rectangle behind the text as a backdrop to the text over the colored image.  This will make the text easier to read during video playback.

![image](https://user-images.githubusercontent.com/78509270/155927910-e937bd36-1447-4735-8864-618c5d89f019.png)

![image](https://user-images.githubusercontent.com/78509270/155927991-8d1192bb-a930-4a7a-92b2-36521766ba2a.png)

The transparency is currently set to 25% and can easily be adjust to be more or less transparent.

**Testing:**
Using the "Lost Coin" bloom file, initialize the "Lost Coin" from scratch.

1. Approve all the slides.
2. Title all the Slides.
3. Record a short voice segment for all slides (this is to work around issue #565 which was closed).
4. Record a Video with the following options: Include Background Music, Pictures & Story Text
5. The video should have a semi transparent grey rectangle behind the text as a backdrop.

The testing was performed on the following configurations:

- Android Studio API 27, Pixel 3 Emulator
- Android Studio API 28, Pixel 2 Emulator
- Android Studio API 29, Pixel 4 Emulator
- Android Studio API 30, Pixel 4 Emulator
- Pixel 5 Hardware, API 31

