### PR TITLE
Clean up wordlinks view for v3.1

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,9 +174,9 @@
     <!-- WordLink Tool -->
     <string name="wordlink_submit_backtranslation_hint">word-for-word backtranslation / transliteration</string>
     <string name="wordlink_close">Close</string>
-    <string name="wordlink_notes">MEANING NOTES. DEFINITIONS:</string>
+    <string name="wordlink_notes"><!--MEANING NOTES. DEFINITIONS:--></string>
     <string name="wordlink_related_terms">RELATED (BUT DIFFERENT) TERMS:</string>
-    <string name="wordlink_other_langauge_examples">OTHER LANGUAGE EXAMPLES:</string>
+    <string name="wordlink_other_langauge_examples"><!--OTHER LANGUAGE EXAMPLES:--></string>
     <string name="wordlink_fill_with_audio_comment">Fill with Audio Comment</string>
     <string name="wordlink_backtranslation">Backtranslation</string>
     <string name="wordlink_none">None</string>


### PR DESCRIPTION
This removes, for now, the UI labels for the wordlinks fields that v3.1 does not show. 