### PR TITLE
upgrading gradle to 7.1.2, AS 2021.1.1, JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ buildscript {
     dependencies {
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
-        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.google.gms:google-services:4.3.10'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,10 +27,10 @@ org.gradle.jvmargs=-Xmx1024m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=false
+#deprecated in gradle 7.1 - android.enableUnitTestBinaryResources=false
 android.useAndroidX=true
 kapt.incremental.apt=true
 
 # When building in TeamCity, the build was failing on jetifier.  This worked around it.
 # https://github.com/square/moshi/issues/804#issuecomment-466456323
-android.jetifier.blacklist = kotlin-compiler-embeddable-.*\\.jar
+android.jetifier.ignorelist = kotlin-compiler-embeddable-.*\\.jar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 org.gradle.configureondemand=false


### PR DESCRIPTION
Got this working in Android Studio 2021.1.1
Needed to do this: in Settings - Build Tools - Gradle selected JDK ver 11
I tested debug app in Pixel 2 API 28 emulator.

[@DaleHensley](https://github.com/DaleHensley) if you approve this PR, in the github pull request, please go to the Files Changed tab and use the green Review Changes button to comment or approve etc.