### PR TITLE
SP635-Show WordLinks help when help button is clicked at WordLinks ac…

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksListActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/wordlink/WordLinksListActivity.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.*
+import android.webkit.WebView
 import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
@@ -19,9 +20,9 @@ import com.google.android.material.navigation.NavigationView
 import org.sil.storyproducer.R
 import org.sil.storyproducer.controller.MainActivity
 import org.sil.storyproducer.controller.RegistrationActivity
-import org.sil.storyproducer.model.WORD_LINKS_CLICKED_TERM
+import org.sil.storyproducer.model.*
 import org.sil.storyproducer.model.PHASE
-import org.sil.storyproducer.model.Workspace
+import org.sil.storyproducer.model.WORD_LINKS_CLICKED_TERM
 import org.sil.storyproducer.model.Workspace.termToWordLinkMap
 
 /**
@@ -68,11 +69,23 @@ class WordLinksListActivity : AppCompatActivity(), SearchView.OnQueryTextListene
                 true
             }
             R.id.helpButton -> {
-                val alert = AlertDialog.Builder(this)
-                        .setTitle(getString(R.string.help))
-                        .setMessage(R.string.wordlink_list_help)
-                        .create()
-                alert.show()
+                // DKH 4/1/2022 - Issue 635: WordLinks list help button does not work.
+                // Display help from the HTML file when the help button is clicked at the activity
+                // level.  Previously, a "NO Help Available" popup was displayed.
+                val wv = WebView(this)  // grab a view that decodes html
+                val iStream = assets.open(Phase.getHelpDocFile(PhaseType.WORD_LINKS)) // open help document
+                val text = iStream.reader().use {  // Read the file
+                    it.readText() }
+                // convert the html to text
+                wv.loadDataWithBaseURL(null,text,"text/html",null,null)
+                // display the help text in a dialog box
+                val dialog = android.app.AlertDialog.Builder(this)
+                        .setTitle("Word Links Help")
+                        .setView(wv)
+                        .setNegativeButton("Close") { dialog, _ ->
+                            dialog!!.dismiss()
+                        }
+                dialog.show()
                 true
             }
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
Per Issue #635 , update code to display WordLinks help when help button is clicked:

WordLinks Activity screen:

![image](https://user-images.githubusercontent.com/78509270/161368182-440907f5-e3ab-4327-a0b5-85759fbb0042.png)

WordLinks Activity help dialogue:
![image](https://user-images.githubusercontent.com/78509270/161368213-fbccbcdf-8e4e-4989-9fea-bec702812c4f.png)

This was tested on a Pixel 5 phone running Android 12.