### PR TITLE
SP637: Allow subtitle text during videos with movement (KB Effect)

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/export/FinalizeActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/export/FinalizeActivity.kt
@@ -312,7 +312,11 @@ class FinalizeActivity : PhaseBaseActivity() {
             mCheckboxText.isChecked = false
         }
 
-
+        // 4/02/2022 - DKH, Issue SP637: Allow text with movement during video creation
+        // With the implementation of SP456 (Add grey rectangle to backdrop text "sub titles"),
+        // the text "sub titles" are now readable during picture movement.  Remove the restriction
+        // that would not allow text "sub titles" to be displayed during picture movement.
+        /*
         if (mCheckboxText.isChecked && mCheckboxKBFX.isChecked) {
             if(currentCheckbox == mCheckboxText){
                 mCheckboxKBFX.isChecked = false
@@ -320,7 +324,7 @@ class FinalizeActivity : PhaseBaseActivity() {
                 mCheckboxText.isChecked = false
             }
         }
-
+        */
         // Check if there is a song to play
         if (mCheckboxSong.isChecked && (Workspace.getSongFilename() == "")){
             // you have to have a song to include it!


### PR DESCRIPTION
Per SP637, Allow subtitle text during videos with movement. 

With the implementation of SP456 (Add grey rectangle to backdrop text "sub titles"), the text sub titles are now readable during picture movement.  Remove the restriction that would not allow text sub titles to be displayed during picture movement.

Tested on Pixel 5 Android 12

Here is an example:

https://user-images.githubusercontent.com/78509270/161406165-1df4a1e6-0641-4ad7-b16d-e78df4c530d1.mp4

For Android 11 releases and later, some Codec encoders have a problem encoding a video with NO picture movement (see Issue #630, fix pull #634).  As tested to date, all Codec encoders are able to process a picture with movement.  With this fix, the user will always be able to display subtitles by using a picture with movement.
 
