### PR TITLE
SP625-When selecting new work space, clear Wordlinks data from memory

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -180,7 +180,7 @@ object Workspace {
         var wordLinksDir = workdocfile.findFile(WORD_LINKS_DIR)
         var csvFileName : String? = null  // csv file name if found
 
-        // DKH - 04/13/2022 Issue 6/25/2022 WordLinks list is incorrectly copied when you select a new SP Templates folder
+        // DKH - 04/13/2022 Issue 625 WordLinks list is incorrectly copied when you select a new SP Templates folder
         // Before we load a new Word Links file, clear any previous Word Links data from memory.
         if(termToWordLinkMap.isNotEmpty()){
             // If the termToWorkLinkMap is not empty, it means the user has selected a new

--- a/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
+++ b/app/src/main/java/org/sil/storyproducer/model/Workspace.kt
@@ -78,6 +78,8 @@ object Workspace {
     var termFormToTermMap: MutableMap<String, String> = mutableMapOf()
     var WLSTree = WordLinkSearchTree()
 
+
+
     var activeStory: Story = emptyStory()
     set(value){
         field = value
@@ -177,6 +179,19 @@ object Workspace {
     private fun importWordLinks(context: Context) {
         var wordLinksDir = workdocfile.findFile(WORD_LINKS_DIR)
         var csvFileName : String? = null  // csv file name if found
+
+        // DKH - 04/13/2022 Issue 6/25/2022 WordLinks list is incorrectly copied when you select a new SP Templates folder
+        // Before we load a new Word Links file, clear any previous Word Links data from memory.
+        if(termToWordLinkMap.isNotEmpty()){
+            // If the termToWorkLinkMap is not empty, it means the user has selected a new
+            // workspace that will contain a different set of word links terms, so,
+            // create an empty link search tree for the newly selected workspace
+            WLSTree = WordLinkSearchTree()
+            // Clear out all term data
+            termToWordLinkMap.clear()
+            termFormToTermMap.clear()
+        }
+
 
         if (wordLinksDir == null) { // check to see if word links directory exists
             // DKH - 11/19/2021 Issue #611 Create Word Links CSV directory if it does not exist


### PR DESCRIPTION
Per Issue #625, clear word links data from memory when selecting a new SP workspace.  

Recreate error as described in #625 and updated software to delete all Wordlinks terms & search trees when switching to a new SP workspace.

This was tested the following devices:
Pixel 5 Android 12
Samsung Android 9