### PR TITLE
Auto-install demo, prompt BL download

### DIFF
--- a/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/MainActivity.kt
@@ -11,12 +11,14 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.webkit.WebView
+import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.GlobalScope
@@ -101,10 +103,31 @@ class MainActivity : BaseActivity(), Serializable {
             }
         }
 
+        checkDownloadStoriesMessage()
+
+    }
+
+    // If only one or two stories are (auto) installed then display short
+    // message to user to explain how to download more bloom templates
+    private fun checkDownloadStoriesMessage() {
+        if (Workspace.storyFilesToScanOrUnzip().size <= 3) {
+            val snackBar = Snackbar.make(
+                    findViewById(R.id.drawer_layout),
+                    R.string.more_story_templates,
+                    20 * 1000   // display for 20 seconds
+            )
+            val snackTextView =
+                snackBar.view.findViewById(com.google.android.material.R.id.snackbar_text) as TextView
+            snackTextView.maxLines = 5  // allow 5 line snack-bar messages
+            snackBar.show()
+        }
     }
 
     override fun onResume() {
         super.onResume()
+
+        checkDownloadStoriesMessage()
+
     }
 
     override fun onStart() {

--- a/app/src/main/java/org/sil/storyproducer/controller/SelectTemplatesFolderController.kt
+++ b/app/src/main/java/org/sil/storyproducer/controller/SelectTemplatesFolderController.kt
@@ -22,7 +22,6 @@ class SelectTemplatesFolderController(
         data?.data?.also { uri ->
             if (result == Activity.RESULT_OK) {
                 setupWorkspace(request, uri)
-                updateStories()
             }
         }
     }
@@ -34,17 +33,19 @@ class SelectTemplatesFolderController(
 
         if (shouldAddDemoToWorkspace(request)) {
             workspace.addDemoToWorkspace(context)
-            updateStories()  // refresh list of stories
         }
+
+        updateStories()  // always refresh list of stories
     }
 
     fun shouldAddDemoToWorkspace(request: Int): Boolean {
         if (request == SELECT_TEMPLATES_FOLDER_AND_ADD_DEMO)
             return true
 
-        // always add demo when no installed stories or stories to unzip - this is awating approval
-//        if (workspace.storyFilesToScanOrUnzip().isEmpty())
-//            return true
+        // always add demo when no installed stories or stories to unzip
+        if (workspace.storyFilesToScanOrUnzip().isEmpty())
+            return true
+
         return false
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@
     <string name="all_stories_tab">All Stories</string>
     <string name="in_progress_tab">In Progress</string>
     <string name="completed_tab">Completed</string>
+    <string name="more_story_templates"><b>Tip:</b>\nIf you are connected to the internet, you can add more story templates!\nTap the menu in the upper left, and choose:\n<b>Download Bloom Library Templates</b></string>
 
     <!-- Filter Toolbar -->
     <string name="film_toolbar">Film</string>


### PR DESCRIPTION
Auto install the 'demo' story if 'SP Templates' folder is empty. 
Whenever story list is short, display a snack-bar message on how the user can download story templates from Bloom Library.
Check download stories message, each time the Main Activity is shown + prevent duplicate demo story